### PR TITLE
Fixed  the spell, that may mislead model

### DIFF
--- a/tools/defaults/config.yaml
+++ b/tools/defaults/config.yaml
@@ -29,7 +29,7 @@ tools:
         required: true
   scroll_up:
     signature: "scroll_up"
-    docstring: "moves the window down {WINDOW} lines"
+    docstring: "moves the window up {WINDOW} lines"
     arguments: []
   scroll_down:
     signature: "scroll_down"


### PR DESCRIPTION
The default action "scroll_up" has inconsistent description, the same as for "scroll_down"

The proposed change fixes the spell in the description of the action

