### PR TITLE
Add .gitattributes and line ending guidelines

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,40 @@
+# Enforce LF line endings for all text files
+* text=auto eol=lf
+
+# Python files
+*.py text diff=python eol=lf
+*.pyi text diff=python eol=lf
+*.pyx text diff=python eol=lf
+*.pxd text diff=python eol=lf
+
+# Documentation
+*.md text diff=markdown eol=lf
+*.rst text eol=lf
+*.txt text eol=lf
+
+# Configuration files
+*.yml text eol=lf
+*.yaml text eol=lf
+*.json text eol=lf
+*.toml text eol=lf
+*.ini text eol=lf
+*.cfg text eol=lf
+
+# Shell scripts
+*.sh text eol=lf
+*.bash text eol=lf
+
+# Git files
+.gitattributes text eol=lf
+.gitignore text eol=lf
+.gitmodules text eol=lf
+
+# Binary files (no line ending conversion)
+*.png binary
+*.jpg binary
+*.gif binary
+*.ico binary
+*.zip binary
+*.gz binary
+*.tar binary
+*.pyc binary

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,3 +14,14 @@ The easiest way to contribute is to give us feedback.
 <!-- INCLUSION END -->
 
 You want to do contribute to the development? Great! Please see the [development guidelines](https://swe-agent.com/latest/dev/contribute/) for guidelines and tips.
+
+## Line Endings
+To ensure consistent behavior across different platforms and prevent patch application issues:
+
+- All text files use LF (Unix-style) line endings
+- This is enforced via `.gitattributes` for all contributors
+- Windows users: Configure Git to handle line endings correctly:
+  ```bash
+  git config --global core.autocrlf input
+  ```
+- If you experience patch failures, check your line endings with `git ls-files --eol`


### PR DESCRIPTION
This PR adds .gitattributes to enforce consistent line endings across the project and updates documentation to prevent future line ending issues.

Changes:
- Add .gitattributes to enforce LF line endings for all text files
- Configure specific file type settings (Python, docs, configs)
- Update CONTRIBUTING.md with line ending guidelines for contributors
- Add instructions for Windows users to configure Git properly

Link to Devin run: https://app.devin.ai/sessions/e14f693390ed47ba87d12698d5834d08

Fixes #702