### PR TITLE
feat: prevent premature command execution in Codespaces

### DIFF
--- a/.devcontainer/postcreate.sh
+++ b/.devcontainer/postcreate.sh
@@ -3,4 +3,12 @@
 set -euo pipefail
 set -x
 
-pip install -e '.'
+./.devcontainer/setup_status.sh start
+
+{
+    pip install -e '.' && \
+    ./.devcontainer/setup_status.sh complete
+} || {
+    ./.devcontainer/setup_status.sh failed
+    exit 1
+}

--- a/.devcontainer/setup_status.sh
+++ b/.devcontainer/setup_status.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+# This script manages the setup status for GitHub Codespaces
+# It creates and updates a status file that can be checked by the CLI
+
+set -euo pipefail
+
+STATUS_FILE="${HOME}/.swe_agent_setup_status"
+
+function mark_setup_started() {
+    echo "setup_started" > "${STATUS_FILE}"
+    chmod 644 "${STATUS_FILE}"  # Ensure file is readable by all users
+}
+
+function mark_setup_complete() {
+    echo "setup_complete" > "${STATUS_FILE}"
+    chmod 644 "${STATUS_FILE}"  # Ensure file is readable by all users
+}
+
+function mark_setup_failed() {
+    echo "setup_failed" > "${STATUS_FILE}"
+    chmod 644 "${STATUS_FILE}"  # Ensure file is readable by all users
+}
+
+# Create status file if it doesn't exist
+touch "${STATUS_FILE}"
+chmod 644 "${STATUS_FILE}"  # Ensure file is readable by all users
+
+case "${1:-}" in
+    "start")
+        mark_setup_started
+        ;;
+    "complete")
+        mark_setup_complete
+        ;;
+    "failed")
+        mark_setup_failed
+        ;;
+    *)
+        echo "Usage: $0 {start|complete|failed}"
+        exit 1
+        ;;
+esac

--- a/docs/installation/codespaces.md
+++ b/docs/installation/codespaces.md
@@ -8,8 +8,8 @@ Running SWE-agent in your browser is the easiest way to try out our project.
 
 1. Click [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/SWE-agent/SWE-agent)
 2. Add your language modelAPI keys to `.env` (find the file in the left sidebar and fill out the template). More information on the keys [here](keys.md).
-3. Make sure to wait until the `postCreateCommand` in the terminal window at the bottom is finished
-4. Enter your SWE-agent command, see, see  [using the command line](../usage/cl_tutorial.md).
+3. Wait for the Codespace setup to complete. The system will prevent you from running commands until setup is finished and display a status message in the terminal.
+4. Enter your SWE-agent command, see [using the command line](../usage/cl_tutorial.md).
 
 ## Running the Web UI
 

--- a/sweagent/run/common.py
+++ b/sweagent/run/common.py
@@ -26,12 +26,11 @@ def check_codespace_setup():
     if not os.getenv("CODESPACES"):
         return True  # Not in Codespaces, no need to check
 
-    status_file = os.path.expanduser("~/.swe_agent_setup_status")
-    if not os.path.exists(status_file):
+    status_file = Path.home() / ".swe_agent_setup_status"
+    if not status_file.exists():
         return True  # No status file, assume not in Codespaces setup
 
-    with open(status_file) as f:
-        status = f.read().strip()
+    status = status_file.read_text().strip()
 
     if status == "setup_started":
         rich_print(Panel.fit(


### PR DESCRIPTION
This PR addresses the issue where users might try to run commands before the Codespace setup is complete.

Changes:
- Add setup status tracking script to monitor Codespace initialization
- Modify postcreate.sh to use status tracking
- Add status checking in CLI to prevent premature command execution
- Update documentation with clearer setup instructions
- Add user-friendly error messages explaining setup status

The change helps prevent confusion and errors by ensuring users can't run commands until the environment is fully ready.

Link to Devin run: https://app.devin.ai/sessions/e14f693390ed47ba87d12698d5834d08

Fixes #354