### PR TITLE
feat: Add Ollama local model support

### DIFF
--- a/config/ollama.yaml
+++ b/config/ollama.yaml
@@ -1,0 +1,135 @@
+agent:
+  templates:
+    system_template: |
+      SETTING: You are an autonomous programmer, and you're working directly in the command line with a special interface.
+
+      The special interface consists of a file editor that shows you {{WINDOW}} lines of a file at a time.
+      In addition to typical bash commands, you can also use specific commands to help you navigate and edit files.
+      To call a command, you need to invoke it with a function call/tool call.
+
+      Please note that THE EDIT COMMAND REQUIRES PROPER INDENTATION.
+
+      For example, if you are looking at this file:
+
+      def fct():
+          print("Hello world")
+
+      and you want to edit the file to read:
+
+      def fct():
+          print("Hello")
+          print("world")
+
+      you search string should be `Hello world` and your replace string should be `"Hello"\n    print("world")`
+      (note the extra spaces before the print statement!).
+
+      You could also get the same result by search for `    print("Hello world")` and replace with `    print("Hello")\n    print("world")`.
+
+      RESPONSE FORMAT:
+      Your shell prompt is formatted as follows:
+      (Open file: <path>)
+      (Current directory: <cwd>)
+      bash-$
+
+      First, you should _always_ include a general thought about what you're going to do next.
+      Then, for every response, you must include exactly _ONE_ tool call/function call.
+
+      Remember, you should always include a _SINGLE_ tool call/function call and then wait for a response from the shell before continuing with more discussion and commands. Everything you include in the DISCUSSION section will be saved for future reference.
+      If you'd like to issue two commands at once, PLEASE DO NOT DO THAT! Please instead first submit just the first tool call, and then after receiving a response you'll be able to issue the second .
+      Note that the environment does NOT support interactive session commands (e.g. python, vim), so please do not invoke them.
+    instance_template: |
+      We're currently solving the following issue within our repository. Here's the issue text:
+      ISSUE:
+      {{problem_statement}}
+
+      INSTRUCTIONS:
+      Now, you're going to solve this issue on your own. Your terminal session has started and you're in the repository's root directory. You can use any bash commands or the special interface to help you. Edit all the files you need to and run any checks or tests that you want.
+      Remember, YOU SHOULD ALWAYS INCLUDE EXACTLY ONE TOOL CALL/FUNCTION CALL PER RESPONSE.
+      When you're satisfied with all of the changes you've made, you can submit your changes to the code base by simply running the submit command.
+      Note however that you cannot use any interactive session commands (e.g. python, vim) in this environment, but you can write scripts and run them. E.g. you can write a python script and then run it with the python command.
+
+      NOTE ABOUT THE EDIT COMMAND: Indentation really matters! When editing a file, make sure to insert appropriate indentation before each line!
+
+      GENERAL IMPORTANT TIPS:
+
+      1. If you run a command and it doesn't work, try running a different command. A command that did not work once will not work the second time unless you modify it!
+
+      2. If you open a file and need to get to an area around a specific line that is not in the first 100 lines, say line 583, don't just use the scroll_down command multiple times. Instead, use the goto 583 command. It's much quicker.
+
+      3. If the bug reproduction script requires inputting/reading a specific file, such as buggy-input.png, and you'd like to understand how to input that file, conduct a search in the existing repo code, to see whether someone else has already done that. Do this by running the command: find_file "buggy-input.png" If that doesn't work, use the linux 'find' command.
+
+      4. Always make sure to look at the currently open file and the current working directory (which appears right after the currently open file). The currently open file might be in a different directory than the working directory! Note that some commands, such as 'create', open files, so they might change the current open file.
+
+      5. When editing files, it is easy to accidentally to write code with incorrect indentation or make other mistakes. Always check the code after you issue an edit to make sure that it reflects what you wanted to accomplish. If it didn't, issue another command to fix it.
+
+      6. When editing files, first explain the code you want to edit and why it is causing the problem. Then explain the edit you want to make and how it fixes the problem. Explain how the edit does not break existing functionality.
+
+      7. Do not try to install any packages with `pip`, `conda`, or any other way. This will usually not work. If the environment is not set up correctly, try to fix the issue without executing python code or running any tests that require the package installed.
+
+      STRATEGY:
+
+      1. Always start by trying to replicate the bug that the issues discusses.
+        If the issue includes code for reproducing the bug, we recommend that you re-implement that in your environment, and run it to make sure you can reproduce the bug.
+        Then start trying to fix it.
+
+        If the bug reproduction script does not print anything when it successfully runs, we recommend adding a print("Script completed successfully, no errors.") command at the end of the file,
+        so that you can be sure that the script indeed ran fine all the way through.
+
+      2. Locate relevant code using the find and search commands. `open` the file you want to edit.
+
+      3. Use the `edit` command to perform edits.
+
+      4. When you think you've fixed the bug, re-run the bug reproduction script to make sure that the bug has indeed been fixed.
+
+      5. Create additional tests to verify the fix in a style similar to the existing reproduction script. In particular, make sure to test edge cases.
+         If you find any issues, go back to the file you edited and perform further edits.
+
+      (Open file: {{open_file}})
+      (Current directory: {{working_dir}})
+      bash-$
+    next_step_template: |-
+      {{observation}}
+      (Open file: {{open_file}})
+      (Current directory: {{working_dir}})
+      bash-$
+    next_step_no_output_template: |-
+      Your command ran successfully and did not produce any output.
+      (Open file: {{open_file}})
+      (Current directory: {{working_dir}})
+      bash-$
+    demonstration_template: |
+      Here is a demonstration of how to correctly accomplish this task.
+      It is included to show you how to correctly use the interface.
+      You do not need to follow exactly what is done in the demonstration.
+      --- DEMONSTRATION ---
+      {{demonstration}}
+      --- END OF DEMONSTRATION ---
+    demonstrations: []
+    put_demos_in_history: false
+
+  tools:
+    env_variables:
+      WINDOW: 100
+      OVERLAP: 2
+    bundles:
+      - path: tools/registry
+      - path: tools/defaults
+      - path: tools/search
+      - path: tools/edit_replace
+      - path: tools/submit
+    enable_bash_tool: true
+    parse_function:
+      type: function_calling
+
+  model:
+    name: ollama
+    model_id: llama2  # Can be changed to any Ollama model
+    api_base: http://localhost:11434
+    temperature: 0.0
+    top_p: 0.95
+    per_instance_cost_limit: 0.0  # Local models have no cost
+    total_cost_limit: 0.0
+    retry:
+      retries: 3
+      min_wait: 1.0
+      max_wait: 20.0

--- a/docs/config/models.md
+++ b/docs/config/models.md
@@ -1,0 +1,68 @@
+# Model Configuration
+
+SWE-agent supports various model configurations through its flexible model system. Here are the available model types:
+
+## Generic API Model
+The base model configuration that works with any LiteLLM-supported model:
+
+```yaml
+agent:
+  model:
+    name: gpt-4  # Any LiteLLM supported model
+    temperature: 0.0
+    top_p: 0.95
+    per_instance_cost_limit: 3.0
+    total_cost_limit: 0.0
+```
+
+## Ollama Local Models
+For running local models through Ollama:
+
+```yaml
+agent:
+  model:
+    name: ollama
+    model_id: llama2  # Any Ollama model identifier
+    api_base: http://localhost:11434  # Ollama API endpoint
+    temperature: 0.0
+    top_p: 0.95
+    per_instance_cost_limit: 0.0  # Local models have no cost
+    total_cost_limit: 0.0
+```
+
+## Replay Model
+For replaying recorded trajectories:
+
+```yaml
+agent:
+  model:
+    name: replay
+    replay_path: path/to/replay.json
+```
+
+## Human Model
+For interactive human input:
+
+```yaml
+agent:
+  model:
+    name: human
+```
+
+## Human Thought Model
+For interactive human input with thought process:
+
+```yaml
+agent:
+  model:
+    name: human_thought
+```
+
+## Instant Empty Submit Model
+For testing purposes:
+
+```yaml
+agent:
+  model:
+    name: instant_empty_submit
+```

--- a/sweagent/agent/models.py
+++ b/sweagent/agent/models.py
@@ -121,6 +121,7 @@ class ReplayModelConfig(GenericAPIModelConfig):
     name: Literal["replay"] = Field(default="replay", description="Model name.")
     model_config = ConfigDict(extra="forbid")
 
+
 class OllamaModelConfig(GenericAPIModelConfig):
     name: Literal["ollama"] = Field(default="ollama", description="Model name.")
     model_id: str = Field(description="Ollama model identifier (e.g. 'llama2', 'mistral', etc.)")
@@ -600,7 +601,12 @@ def get_model(args: ModelConfig, tools: ToolConfig) -> AbstractModel:
     """Returns correct model object given arguments and commands"""
     # Convert GenericAPIModelConfig to specific model config if needed
     if isinstance(args, GenericAPIModelConfig) and not isinstance(
-        args, HumanModelConfig | HumanThoughtModelConfig | ReplayModelConfig | InstantEmptySubmitModelConfig | OllamaModelConfig
+        args,
+        HumanModelConfig
+        | HumanThoughtModelConfig
+        | ReplayModelConfig
+        | InstantEmptySubmitModelConfig
+        | OllamaModelConfig,
     ):
         if args.name == "human":
             args = HumanModelConfig(**args.model_dump())

--- a/tests/test_ollama_model.py
+++ b/tests/test_ollama_model.py
@@ -1,6 +1,7 @@
 """Tests for Ollama model integration."""
+
 import pytest
-from pathlib import Path
+
 from sweagent.agent.models import OllamaModelConfig, get_model
 from sweagent.agent.tools import ToolConfig
 
@@ -55,6 +56,7 @@ def test_ollama_model_config_validation():
 def test_ollama_model_from_generic():
     """Test creating Ollama model from generic config."""
     from sweagent.agent.models import GenericAPIModelConfig
+
     config = GenericAPIModelConfig(
         name="ollama",
         api_base="http://localhost:11434",

--- a/tests/test_ollama_model.py
+++ b/tests/test_ollama_model.py
@@ -1,0 +1,68 @@
+"""Tests for Ollama model integration."""
+import pytest
+from pathlib import Path
+from sweagent.agent.models import OllamaModelConfig, get_model
+from sweagent.agent.tools import ToolConfig
+
+
+def test_ollama_model_config():
+    """Test Ollama model configuration."""
+    config = OllamaModelConfig(
+        name="ollama",
+        model_id="llama2",
+        api_base="http://localhost:11434",
+        temperature=0.0,
+        top_p=0.95,
+    )
+    assert config.name == "ollama"
+    assert config.model_id == "llama2"
+    assert config.api_base == "http://localhost:11434"
+
+
+def test_ollama_model_creation():
+    """Test Ollama model creation through get_model."""
+    config = OllamaModelConfig(
+        name="ollama",
+        model_id="llama2",
+        api_base="http://localhost:11434",
+        temperature=0.0,
+        top_p=0.95,
+    )
+    tools = ToolConfig()  # Default tool config
+    model = get_model(config, tools)
+    assert model is not None
+    # Model name should be converted to LiteLLM format
+    assert model.args.name == "ollama/llama2"
+
+
+def test_ollama_model_config_validation():
+    """Test Ollama model configuration validation."""
+    with pytest.raises(ValueError):
+        OllamaModelConfig(
+            name="not_ollama",  # Invalid name
+            model_id="llama2",
+            api_base="http://localhost:11434",
+        )
+
+    with pytest.raises(ValueError):
+        OllamaModelConfig(
+            name="ollama",
+            model_id="",  # Empty model_id
+            api_base="http://localhost:11434",
+        )
+
+
+def test_ollama_model_from_generic():
+    """Test creating Ollama model from generic config."""
+    from sweagent.agent.models import GenericAPIModelConfig
+    config = GenericAPIModelConfig(
+        name="ollama",
+        api_base="http://localhost:11434",
+        temperature=0.0,
+        top_p=0.95,
+    )
+    tools = ToolConfig()
+    model = get_model(config, tools)
+    assert model is not None
+    assert isinstance(model.args, OllamaModelConfig)
+    assert model.args.api_base == "http://localhost:11434"


### PR DESCRIPTION
# Add Ollama Local Model Support

This PR adds support for Ollama local models through LiteLLM integration, enabling users to run SWE-agent with locally hosted models like LLaMa and Qwen.

## Changes
- Add `OllamaModelConfig` class for local model configuration
- Extend LiteLLM integration to support Ollama endpoints
- Add comprehensive test suite for Ollama model integration
- Add documentation and example configuration

## Testing
- Added unit tests for configuration validation
- Added tests for model creation and initialization
- Added tests for configuration conversion
- Added parameter validation tests

## Documentation
- Added Ollama configuration documentation
- Created example ollama.yaml configuration
- Added usage instructions

Link to Devin run: https://app.devin.ai/sessions/57d1cf33292440e6ba72a487ab4e049b
