### PR TITLE
feat: Add warning for ignored model argument with Azure endpoints

### DIFF
--- a/sweagent/agent/models.py
+++ b/sweagent/agent/models.py
@@ -431,6 +431,17 @@ class LiteLLMModel(AbstractModel):
         self.args = args
         self.stats = InstanceStats()
         self.tools = tools
+
+        # Check for Azure endpoint and warn about ignored model argument
+        if self.args.api_base and "azure" in self.args.api_base.lower():
+            self.logger = get_logger("swea-lm", emoji="🤖")
+            self.logger.warning(
+                "Using Azure endpoint - the --model CLI argument will be ignored. "
+                "The model is determined by OPENAI_API_VERSION instead."
+            )
+        else:
+            self.logger = get_logger("swea-lm", emoji="🤖")
+
         if tools.use_function_calling:
             if not litellm.utils.supports_function_calling(model=self.args.name):
                 msg = f"Model {self.args.name} does not support function calling"
@@ -438,7 +449,6 @@ class LiteLLMModel(AbstractModel):
         self.model_max_input_tokens = litellm.model_cost.get(self.args.name, {}).get("max_input_tokens")
         self.model_max_output_tokens = litellm.model_cost.get(self.args.name, {}).get("max_output_tokens")
         self.lm_provider = litellm.model_cost[self.args.name]["litellm_provider"]
-        self.logger = get_logger("swea-lm", emoji="🤖")
 
     def _update_stats(self, *, input_tokens: int, output_tokens: int, cost: float) -> None:
         with GLOBAL_STATS_LOCK:

--- a/tests/test_azure_model.py
+++ b/tests/test_azure_model.py
@@ -13,7 +13,8 @@ def test_azure_endpoint_warning(caplog):
     )
     tools = ToolConfig()
 
-    model = LiteLLMModel(config, tools)
+    # Initialize model to trigger warning
+    LiteLLMModel(config, tools)
 
     assert any(
         "Using Azure endpoint - the --model CLI argument will be ignored" in record.message
@@ -29,7 +30,8 @@ def test_non_azure_endpoint_no_warning(caplog):
     )
     tools = ToolConfig()
 
-    model = LiteLLMModel(config, tools)
+    # Initialize model to verify no warning
+    LiteLLMModel(config, tools)
 
     assert not any(
         "Using Azure endpoint - the --model CLI argument will be ignored" in record.message

--- a/tests/test_azure_model.py
+++ b/tests/test_azure_model.py
@@ -1,0 +1,37 @@
+"""Tests for Azure model configuration and warnings."""
+import pytest
+from sweagent.agent.models import GenericAPIModelConfig, LiteLLMModel
+from sweagent.agent.tools import ToolConfig
+
+
+def test_azure_endpoint_warning(caplog):
+    """Test that using Azure endpoint with model argument shows warning."""
+    config = GenericAPIModelConfig(
+        name="gpt-4",
+        api_base="https://example.azure.openai.azure.com",
+        api_version="2023-05-15"
+    )
+    tools = ToolConfig()
+
+    model = LiteLLMModel(config, tools)
+
+    assert any(
+        "Using Azure endpoint - the --model CLI argument will be ignored" in record.message
+        for record in caplog.records
+    )
+
+
+def test_non_azure_endpoint_no_warning(caplog):
+    """Test that using non-Azure endpoint does not show warning."""
+    config = GenericAPIModelConfig(
+        name="gpt-4",
+        api_base="https://api.openai.com/v1"
+    )
+    tools = ToolConfig()
+
+    model = LiteLLMModel(config, tools)
+
+    assert not any(
+        "Using Azure endpoint - the --model CLI argument will be ignored" in record.message
+        for record in caplog.records
+    )


### PR DESCRIPTION
When using Azure endpoints, the --model CLI argument is ignored as the model is determined by OPENAI_API_VERSION. This change adds a warning message to inform users about this behavior.

Changes:
- Added warning in LiteLLMModel.__init__ when Azure endpoint is detected
- Created tests to verify warning behavior for Azure and non-Azure endpoints
- Ensures users are informed when their model argument will be ignored

Link to Devin run: https://app.devin.ai/sessions/57d1cf33292440e6ba72a487ab4e049b

Fixes #571