### PR TITLE
Enforce swe rex version lower bound

### DIFF
--- a/sweagent/__init__.py
+++ b/sweagent/__init__.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from functools import partial
 
 from git import Repo
+from packaging import version
 
 __version__ = "1.0.0"
 
@@ -70,6 +71,18 @@ def get_agent_version_info() -> str:
     return f"This is SWE-agent version {__version__} ({hash}) with SWE-ReX {rex_version} ({rex_hash})."
 
 
+def impose_rex_lower_bound() -> None:
+    rex_version = get_rex_version()
+    minimal_rex_version = "1.0.3"
+    if version.parse(rex_version) < version.parse(minimal_rex_version):
+        msg = (
+            f"SWE-ReX version {rex_version} is too old. Please update to at least {minimal_rex_version}. "
+            "You can also rerun `pip install -e .` in this repository to install the latest version."
+        )
+        raise RuntimeError(msg)
+
+
+impose_rex_lower_bound()
 get_logger("swe-agent", emoji="👋").info(get_agent_version_info())
 
 


### PR DESCRIPTION
Gives users guidance if they would otherwise hit:

```
╭───────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ Validation error                                                                                                  │
│                                                                                                                   │
│ The following errors are raised by Pydantic, trying to instantiate the configuration based on                     │
│ the merged configuration dictionary (see above).                                                                  │
│                                                                                                                   │
│ Every new indented block corresponds to a different error from Pydantic.                                          │
│ The first line of each block is the attribute that failed validation, the following lines are the error messages. │
│                                                                                                                   │
│ If you see many lines of errors, there are probably different ways to instantiate the same object (a union type). │
│ For example, there are different deployments with different options each. Pydantic is then trying                 │
│ one after the other and reporting the failures for each of them.                                                  │
│ More on union types: https://swe-agent.com/latest/usage/cl_tutorial/#union-types                                  │
│                                                                                                                   │
│ 1 validation error for DockerDeploymentConfig                                                                     │
│ python_standalone_dir                                                                                             │
│   Extra inputs are not permitted                                                                                  │
│     For further information visit https://errors.pydantic.dev/2.9/v/extra_forbidden                               │
╰───────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
Traceback (most recent call last):
  File "/opt/miniconda3/envs/swea13/bin/sweagent", line 8, in <module>
    sys.exit(main())
             ~~~~^^
  File "/Users/fuchur/Documents/24/git_sync/SWE-agent/sweagent/run/run.py", line 81, in main
    run_single_main(remaining_args)
    ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^
  File "/Users/fuchur/Documents/24/git_sync/SWE-agent/sweagent/run/run_single.py", line 208, in run_from_cli
    run_from_config(BasicCLI(RunSingleConfig, help_text=help_text).get_config(args))  # type: ignore
                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^
  File "/Users/fuchur/Documents/24/git_sync/SWE-agent/sweagent/run/common.py", line 345, in get_config
    raise RuntimeError(msg) from None
RuntimeError: Invalid configuration. Please check the above output.
```