### PR TITLE
Doc: Fix line endings for multi-line bash commands

### DIFF
--- a/docs/usage/batch_mode.md
+++ b/docs/usage/batch_mode.md
@@ -17,18 +17,20 @@ sweagent run-batch \
     --config config/default.yaml \
     --agent.model.name gpt-4o \
     --agent.model.per_instance_cost_limit 2.00 \
-    --instances.type swe_bench \  # (1)!
-    --instances.subset lite \  # (2)!
-    --instances.split dev  \  # (3)!
-    --instances.slice :3 \  # (4)!
-    --instances.shuffle=True  # (5)!
+    --instances.type swe_bench \
+    --instances.subset lite \
+    --instances.split dev  \
+    --instances.slice :3 \
+    --instances.shuffle=True
 ```
 
-1. There's a couple of built-in ways to configure instances. This option selects the SWE-bench dataset.
-2. There's a few datasets provided by the SWE-bench project. Lite is a subset of GitHub issues with a few heuristic filters that makes them more likely to be solvable.
-3. Most datasets have a `dev` and a `test` split.
-4. The `--slice` option allows you to select a subset of instances from the dataset. It works just the way to pythons `list[...]` slicing, so you can specify `:10` to take the first 10 instances, `10:20` to take the next 10, `-10:` to take the last 10, or `10:20:2` to take every second instance in that range.
-5. Shuffle all instances before slicing.
+Let's look at the options:
+
+1. `--instances.type swe_bench`: There's a couple of built-in ways to configure instances. This option selects the SWE-bench dataset.
+2. `--instances.subset lite`: There's a few datasets provided by the SWE-bench project. Lite is a subset of GitHub issues with a few heuristic filters that makes them more likely to be solvable.
+3. `--instances.split dev`: Most datasets have a `dev` and a `test` split.
+4. `--instances.slice :3`: The `--slice` option allows you to select a subset of instances from the dataset. It works just the way to pythons `list[...]` slicing, so you can specify `:10` to take the first 10 instances, `10:20` to take the next 10, `-10:` to take the last 10, or `10:20:2` to take every second instance in that range.
+5. `--instances.shuffle=True`: Shuffle all instances before slicing. This is a deterministic operation, so the same command will always return the same instances in the same order.
 
 * There's some things that you should recognize: All of the `--agent` options are available and you can still specify `--config` files.
 * However, the `--problem_statement`, `--repo`, and `--env` options obviously need to change, because you now want to populate these settings automatically from a source.
@@ -84,12 +86,12 @@ sweagent run-batch \
     --config config/default.yaml \
     --agent.model.name gpt-4o \
     --instances.type file \
-    --instances.path instances.yaml  # (1)!
+    --instances.path instances.yaml \
     --instances.slice :3 \
     --instances.shuffle=True
 ```
 
-1. We support `.jsonl`, `.json`, and `.yaml` files.
+`--instances.path` supports `.jsonl`, `.json`, and `.yaml` files.
 
 Here'the simplest example of what such a file can look like
 

--- a/docs/usage/cl_tutorial.md
+++ b/docs/usage/cl_tutorial.md
@@ -30,14 +30,14 @@ python run.py \
 ```bash title="Fix a bug in a local repository using a custom docker image" hl_lines="4 5 6"
 git clone https://github.com/SWE-agent/test-repo.git
 python run.py \
-  --agent.model.name=claude-3.5 \  # (1)!
+  --agent.model.name=claude-3.5 \
   --env.repo.path=test-repo \
   --problem_statement.path=test-repo/problem_statements/1.md \
-  --env.deployment.image=python:3.12  # (2)!
+  --env.deployment.image=python:3.12
 ```
 
-1. Make sure to add anthropic keys to the environment for this one!
-2. This points to the [dockerhub image](https://hub.docker.com/_/python) of the same name
+1. Make sure to add anthropic keys (or keys for your model provider) to the environment for this one!
+2. `--env.deployment.image` points to the [dockerhub image](https://hub.docker.com/_/python) of the same name
 
 
 For the next example, we will use a cloud-based execution environment instead of using local docker containers.
@@ -208,11 +208,11 @@ In addition, you can also execute additional commands before starting the agent 
 ```bash
 sweagent run \
     --agent.model.name=claude-3-5-sonnet-20241022 \
-    --env.post_startup_commands='["pip install flake8"]' \  # (1)!
+    --env.post_startup_commands='["pip install flake8"]' \
     ...
 ```
 
-1. Note the list syntax that is passed as a string using single ticks `'`. This is particularly important for `zsh` where `[`, `]` have special meaning.
+Note the list syntax that is passed as a string using single ticks `'`. This is particularly important for `zsh` where `[`, `]` have special meaning.
 
 Here's an example of a custom docker environment (it's also available in the repo as `docker/tiny_test.Dockerfile`):
 
@@ -238,6 +238,8 @@ SHELL ["/bin/bash", "-c"]
 # This is where pipx installs things
 ENV PATH="$PATH:/root/.local/bin/"  # (7)!
 ```
+
+Click on the :material-chevron-right-circle: icon in the right margin of the code snippet to see more information about the lines.
 
 1. This is the base image.
 2. This is to avoid any interactive prompts from the package manager.

--- a/docs/usage/hello_world.md
+++ b/docs/usage/hello_world.md
@@ -20,14 +20,11 @@ Let's start with an absolutely trivial example and solve an issue about a simple
 
 ```bash
 sweagent run \
-  --agent.model.name=claude-3-5-sonnet-20241022 \ # (1)!
-  --agent.model.per_instance_cost_limit=2.00 \ # (2)!
+  --agent.model.name=claude-3-5-sonnet-20241022 \
+  --agent.model.per_instance_cost_limit=2.00 \
   --env.repo.github_url=https://github.com/SWE-agent/test-repo \
   --problem_statement.github_url=https://github.com/SWE-agent/test-repo/issues/1
 ```
-
-1. We recommend either `Claude 3.5 Sonnet` or `GPT-4o` for this tutorial.
-2. This limits the inference cost per instance (per solved problem) to $2. The default is $3.
 
 !!! tip "Annotations"
     Notice the :material-chevron-right-circle: icon in the right margin in the code snippet? Click on it to display more information


### PR DESCRIPTION
Fixes #890 (it seems like the JS based approach didn't seem to work so lets get rid of the annotations)