### PR TITLE
Forces platform to be linux/amd64 for swe-bench batch runs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ dependencies = [
     "litellm",
     "GitPython",
     "ghapi",
-    "swe-rex>=1.0.3",
+    "swe-rex>=1.2.0",
     "tabulate",
 ]
 

--- a/sweagent/__init__.py
+++ b/sweagent/__init__.py
@@ -53,7 +53,7 @@ def get_agent_commit_hash() -> str:
     try:
         repo = Repo(REPO_ROOT, search_parent_directories=False)
     except Exception:
-        return ""
+        return "unavailable"
     return repo.head.object.hexsha
 
 
@@ -63,7 +63,7 @@ def get_rex_commit_hash() -> str:
     try:
         repo = Repo(Path(swerex.__file__).resolve().parent.parent.parent, search_parent_directories=False)
     except Exception:
-        return ""
+        return "unavailable"
     return repo.head.object.hexsha
 
 
@@ -77,12 +77,12 @@ def get_agent_version_info() -> str:
     hash = get_agent_commit_hash()
     rex_hash = get_rex_commit_hash()
     rex_version = get_rex_version()
-    return f"This is SWE-agent version {__version__} ({hash}) with SWE-ReX {rex_version} ({rex_hash})."
+    return f"This is SWE-agent version {__version__} ({hash=}) with SWE-ReX version {rex_version} ({rex_hash=})."
 
 
 def impose_rex_lower_bound() -> None:
     rex_version = get_rex_version()
-    minimal_rex_version = "1.1.0"
+    minimal_rex_version = "1.2.0"
     if version.parse(rex_version) < version.parse(minimal_rex_version):
         msg = (
             f"SWE-ReX version {rex_version} is too old. Please update to at least {minimal_rex_version}. "

--- a/sweagent/run/batch_instances.py
+++ b/sweagent/run/batch_instances.py
@@ -269,6 +269,7 @@ class SWEBenchInstances(BaseModel, AbstractInstanceSource):
         from datasets import load_dataset
 
         ds: list[dict[str, Any]] = load_dataset(self._get_huggingface_name(), split=self.split)  # type: ignore
+        self.deployment.platform = "linux/amd64"
         instances = [
             SimpleBatchInstance.from_swe_bench(instance).to_full_batch_instance(self.deployment) for instance in ds
         ]


### PR DESCRIPTION
This PR depends on pending PR https://github.com/SWE-agent/SWE-ReX/pull/165

#### Reference Issues/PRs
Fixes #893 
Fixes #936

#### What does this implement/fix? Explain your changes.
For swe-bench batch instances, we set the platform to be linux/amd64 deterministically, which allows the `python_standalone_dir` to be built and set properly in swe-rex, enabling faster swe-bench batch runs on `amd64` arch machines.


> Note!
We'll need to update the dependencies to require a new swe-rex version, once https://github.com/SWE-agent/SWE-ReX/pull/165 is merged to swe-rex