### PR TITLE
Pin textual to version 1.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ dependencies = [
     "ghapi",
     "swe-rex>=1.0.3",
     "tabulate",
+    "textual==1.0.0",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ dependencies = [
     "ghapi",
     "swe-rex>=1.0.3",
     "tabulate",
-    "textual==1.0.0",
+    "textual>=1.0.0,<2.0.0",
 ]
 
 [project.scripts]


### PR DESCRIPTION
Pin `textual` dependency as the inspector fails to start without textual and crashes if a version above 1.0.0 is installed. I'm observing this behavior with `uv` which presumably hides `textual` included by transitive deps (to repro: `uv venv -p 3.11` + `uv sync`, then `uv run sweagent ...`)

Error message without textual dependency.
```
$ sweagent i trajectories/demonstrations/replay__marshmallow-code__marshmallow-1867__default_sys-env_cursors_window100__t-0.20__p-0.95__c-2.00__install-1

👋 INFO     This is SWE-agent version 1.0.0 (7f74ae7390b8efd66e07913270c2738cc7e3bba9) with SWE-ReX 1.1.1 ().                                                                              
Traceback (most recent call last):
  File <redacted>/.venv/bin/sweagent", line 10, in <module>
    sys.exit(main())
             ^^^^^^
  File "<redacted>/sweagent/run/run.py", line 113, in main
    from sweagent.run.inspector_cli import main as inspect_main
  File "<redacted>/sweagent/run/inspector_cli.py", line 13, in <module>
    from textual.app import App, ComposeResult
ModuleNotFoundError: No module named 'textual'
```

Error message from textual v2+. Can be reproduced with above command and pressing `l` to navigate through the trajectory.
```
MarkupError: Expected markup style value (found ': /marshmallow-code__marshmallow/reproduce.py (1 lines total)]\n').
```

#### Reference Issues/PRs
Not applicaple.

#### What does this implement/fix? Explain your changes.
Pin textual to version 1.0.0.

