### PR TITLE
Run Batch: Allow passing custom instances source config

### DIFF
--- a/sweagent/run/batch_instances.py
+++ b/sweagent/run/batch_instances.py
@@ -308,4 +308,6 @@ class ExpertInstancesFromFile(BaseModel, AbstractInstanceSource):
         return self.path.stem
 
 
-BatchInstanceSourceConfig = InstancesFromHuggingFace | InstancesFromFile | SWEBenchInstances | ExpertInstancesFromFile
+BatchInstanceSourceConfig = (
+    InstancesFromHuggingFace | InstancesFromFile | SWEBenchInstances | ExpertInstancesFromFile | AbstractInstanceSource
+)


### PR DESCRIPTION
Allow passing arbitrary implementations of `AbstractInstanceSource` by adding it to the union type in the pydantic model. It currently raises when trying to construct the RunBatchConfig with a different instances source.

#### Reference Issues/PRs
None

#### What does this implement/fix? Explain your changes.
N/A