### PR TITLE
OpenAI API: Don't pass None tool_calls to the OpenAI API

### DIFF
--- a/sweagent/agent/models.py
+++ b/sweagent/agent/models.py
@@ -751,8 +751,8 @@ class LiteLLMModel(AbstractModel):
                     # Only one tool call per observations
                     "tool_call_id": history_item["tool_call_ids"][0],  # type: ignore
                 }
-            elif "tool_calls" in history_item:
-                message = {"role": role, "content": history_item["content"], "tool_calls": history_item["tool_calls"]}
+            elif (tool_calls := history_item.get("tool_calls")) is not None:
+                message = {"role": role, "content": history_item["content"], "tool_calls": tool_calls}
             else:
                 message = {"role": role, "content": history_item["content"]}
             if "cache_control" in history_item:


### PR DESCRIPTION
The current chat completions may include `tool_calls=None`, which trips up some OpenAI-compatible HTTP servers.

The `tool_calls` field is always present AFAICT, so this PR changes the logic to only set tool_calls when it's non-`None`.

#### Reference Issues/PRs
None.

#### What does this implement/fix? Explain your changes.
N/A.
