### PR TITLE
Fix "TypeError: Cannot read properties of null (reading 'replace')" in Trajectory viewer

### DIFF
--- a/sweagent/inspector/fileViewer.js
+++ b/sweagent/inspector/fileViewer.js
@@ -39,7 +39,6 @@ function createTrajectoryItem(item, index) {
     if (!text) {
       return "";
     }
-    console.log(text);
     return text
       .replace(/&/g, "&amp;")
       .replace(/</g, "&lt;")

--- a/sweagent/inspector/fileViewer.js
+++ b/sweagent/inspector/fileViewer.js
@@ -37,7 +37,6 @@ function createTrajectoryItem(item, index) {
 
   const escapeHtml = (text) => {
     if (!text) {
-      // Raise exception
       return "";
     }
     console.log(text);

--- a/sweagent/inspector/fileViewer.js
+++ b/sweagent/inspector/fileViewer.js
@@ -36,6 +36,11 @@ function createTrajectoryItem(item, index) {
   const hasMessages = item.messages && item.messages.length > 0;
 
   const escapeHtml = (text) => {
+    if (!text) {
+      // Raise exception
+      return "";
+    }
+    console.log(text);
     return text
       .replace(/&/g, "&amp;")
       .replace(/</g, "&lt;")


### PR DESCRIPTION
Sometimes Trajectory viewer fails to load a file
and throws an error "TypeError: Cannot read properties of null (reading 'replace')". This is because there is a possibility for `item.action` to be `none`.

<!--
Thanks for contributing a pull request!
-->

#### Reference Issues/PRs
<!--
Example: "Fixes #1234", "See also #3456"
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### What does this implement/fix? Explain your changes.
<!--
Please include a brief explanation of how your solution
fixes the tagged issue(s), along with what files / entities have
been modified for this fix.
-->

![image](https://github.com/user-attachments/assets/c78bb8f9-d407-4603-b68f-0a7150de1ec3)
