### PR TITLE
tools, fix exit_forfeit signature

### DIFF
--- a/tools/forfeit/config.yaml
+++ b/tools/forfeit/config.yaml
@@ -1,5 +1,5 @@
 tools:
   exit_forfeit:
-    signature: "exit_forfeit"
+    signature: "exit"
     docstring: "Give up on the current challenge and terminate the session."
     arguments: []


### PR DESCRIPTION
Summary: The signature is `exit_forfeit` but the code checking for it look for `exit`. i.e. see sweagent/agent/agents.py:895

This PR changes the signature to match (instead of changing the relevant checking logic).

Closes #1011 
