### PR TITLE
chore: Enable anthropic header for output-128k

### DIFF
--- a/sweagent/agent/models.py
+++ b/sweagent/agent/models.py
@@ -645,6 +645,9 @@ class LiteLLMModel(AbstractModel):
         completion_kwargs = self.config.completion_kwargs
         if self.lm_provider == "anthropic":
             completion_kwargs["max_tokens"] = self.model_max_output_tokens
+            completion_kwargs["extra_headers"] = {
+                'anthropic-beta': 'output-128k-2025-02-19'
+            }
         try:
             response: litellm.types.utils.ModelResponse = litellm.completion(  # type: ignore
                 model=self.config.name,


### PR DESCRIPTION
I was using the model sonnet and I got into problems because of the output tokens being limited to 60000. I added this value output-128k-2025-02-19 to the anthropic-beta header.

<!--
Thanks for contributing a pull request!
-->

#### Reference Issues/PRs
<!--
Example: "Fixes #1234", "See also #3456"
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### What does this implement/fix? Explain your changes.
<!--
Please include a brief explanation of how your solution
fixes the tagged issue(s), along with what files / entities have
been modified for this fix.
-->
