### PR TITLE
chore: Change function calling check Exception to only raising a warning

### DIFF
--- a/sweagent/agent/models.py
+++ b/sweagent/agent/models.py
@@ -560,6 +560,8 @@ class LiteLLMModel(AbstractModel):
         self.config: GenericAPIModelConfig = args.model_copy(deep=True)
         self.stats = InstanceStats()
         self.tools = tools
+        self.logger = get_logger("swea-lm", emoji="🤖")
+        
         if tools.use_function_calling:
             if not litellm.utils.supports_function_calling(model=self.config.name):
                 msg = (
@@ -567,7 +569,7 @@ class LiteLLMModel(AbstractModel):
                     " does not support function calling, you can use `parse_function='thought_action'` instead. "
                     "See https://swe-agent.com/latest/faq/ for more information."
                 )
-                raise ModelConfigurationError(msg)
+                self.logger.warning(msg)
 
         if self.config.max_input_tokens is not None:
             self.model_max_input_tokens = self.config.max_input_tokens
@@ -580,7 +582,7 @@ class LiteLLMModel(AbstractModel):
             self.model_max_output_tokens = litellm.model_cost.get(self.config.name, {}).get("max_output_tokens")
 
         self.lm_provider = litellm.model_cost.get(self.config.name, {}).get("litellm_provider")
-        self.logger = get_logger("swea-lm", emoji="🤖")
+        
 
     @property
     def instance_cost_limit(self) -> float:

--- a/sweagent/agent/models.py
+++ b/sweagent/agent/models.py
@@ -561,7 +561,7 @@ class LiteLLMModel(AbstractModel):
         self.stats = InstanceStats()
         self.tools = tools
         self.logger = get_logger("swea-lm", emoji="🤖")
-        
+
         if tools.use_function_calling:
             if not litellm.utils.supports_function_calling(model=self.config.name):
                 msg = (
@@ -582,7 +582,6 @@ class LiteLLMModel(AbstractModel):
             self.model_max_output_tokens = litellm.model_cost.get(self.config.name, {}).get("max_output_tokens")
 
         self.lm_provider = litellm.model_cost.get(self.config.name, {}).get("litellm_provider")
-        
 
     @property
     def instance_cost_limit(self) -> float:


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!
-->

#### Reference Issues/PRs
Fixes #1038 

#### What does this implement/fix? Explain your changes.
This Merge Request removes the hard check for specific model names. It changes the following lines:

```python
if tools.use_function_calling:
            if not litellm.utils.supports_function_calling(model=self.config.name):
                msg = (
                    f"Model {self.config.name} does not support function calling. If your model"
                    " does not support function calling, you can use `parse_function='thought_action'` instead. "
                    "See https://swe-agent.com/latest/faq/ for more information."
                )
                raise ModelConfigurationError(msg)
```
This current code does not allow for custom model names, which are (sadly) sometimes the case (e.g. `azure/4o-mini` would not work, because it's not in the list of LiteLLM models)

Because sometimes custom names / mappings are required, this change turns the Exception into a logger warning instead, so the user can see the risk, however still use the software if it's required to be used with a custom name.
