### PR TITLE
Fix: fix Windows path error, replace Path with PurePosixPath or string

### DIFF
--- a/sweagent/agent/agents.py
+++ b/sweagent/agent/agents.py
@@ -5,7 +5,7 @@ import copy
 import json
 import logging
 import time
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Annotated, Any, Literal
 
 import yaml
@@ -867,7 +867,7 @@ class DefaultAgent(AbstractAgent):
                 pf = (
                     PatchFormatter(
                         patch,
-                        read_method=lambda path: self._env.read_file(Path("/") / self._env.repo.repo_name / path),  # type: ignore[attr-defined]
+                        read_method=lambda path: self._env.read_file(PurePosixPath("/") / self._env.repo.repo_name / path),  # type: ignore[attr-defined]
                     )
                     if patch
                     else None

--- a/sweagent/agent/agents.py
+++ b/sweagent/agent/agents.py
@@ -867,7 +867,9 @@ class DefaultAgent(AbstractAgent):
                 pf = (
                     PatchFormatter(
                         patch,
-                        read_method=lambda path: self._env.read_file(PurePosixPath("/") / self._env.repo.repo_name / path),  # type: ignore[attr-defined]
+                        read_method=lambda path: self._env.read_file(
+                            PurePosixPath("/") / self._env.repo.repo_name / path
+                        ),  # type: ignore[attr-defined]
                     )
                     if patch
                     else None

--- a/sweagent/tools/tools.py
+++ b/sweagent/tools/tools.py
@@ -263,7 +263,7 @@ class ToolHandler:
     def _get_state(self, env: SWEEnv) -> dict[str, str]:
         """Retrieve the state from the environment"""
         try:
-            state_str = env.read_file(Path("/root/state.json"))
+            state_str = env.read_file("/root/state.json")
         except FileNotFoundError:
             self.logger.warning("State file not found, returning empty state")
             return {}


### PR DESCRIPTION
fix #1048

<!--
Thanks for contributing a pull request!
-->

#### Reference Issues/PRs
<!--
 "Fixes #1048
-->

#### What does this implement/fix? Explain your changes.
<!--
see also #1048 
The Path in Python behaves differently across platforms: it uses \ on Windows and / on Unix.
So I replace path with string or PurePosixPath
-->
