### PR TITLE
Use default trajectories dir according to ENV

### DIFF
--- a/sweagent/run/run_batch.py
+++ b/sweagent/run/run_batch.py
@@ -45,9 +45,9 @@ import yaml
 from pydantic import Field, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 from rich.live import Live
-from sweagent import TRAJECTORY_DIR
 from swerex.deployment.hooks.status import SetStatusDeploymentHook
 
+from sweagent import TRAJECTORY_DIR
 from sweagent.agent.agents import AgentConfig, get_agent_from_config
 from sweagent.agent.hooks.status import SetStatusAgentHook
 from sweagent.environment.hooks.status import SetStatusEnvironmentHook

--- a/sweagent/run/run_batch.py
+++ b/sweagent/run/run_batch.py
@@ -45,6 +45,7 @@ import yaml
 from pydantic import Field, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 from rich.live import Live
+from sweagent import TRAJECTORY_DIR
 from swerex.deployment.hooks.status import SetStatusDeploymentHook
 
 from sweagent.agent.agents import AgentConfig, get_agent_from_config
@@ -112,7 +113,7 @@ class RunBatchConfig(BaseSettings, cli_implicit_flags=False):
             if config_file != "no_config":
                 config_file = Path(config_file).stem
             suffix = f"__{self.suffix}" if self.suffix else ""
-            self.output_dir = Path.cwd() / "trajectories" / user_id / f"{config_file}__{model_id}___{source_id}{suffix}"
+            self.output_dir = TRAJECTORY_DIR / user_id / f"{config_file}__{model_id}___{source_id}{suffix}"
 
     @model_validator(mode="after")
     def evaluate_and_redo_existing(self) -> Self:


### PR DESCRIPTION
According to the changes in #1046 where the default trajectories directory is set here:

https://github.com/SWE-agent/SWE-agent/blob/71f2ed93d544b6fbd3b5d52792679579175fc881/sweagent/__init__.py#L46

It looks like it should be used here:

https://github.com/SWE-agent/SWE-agent/blob/71f2ed93d544b6fbd3b5d52792679579175fc881/sweagent/run/run_batch.py#L115