### PR TITLE
Missing rich_print made help message difficult to read.

### DIFF
--- a/sweagent/run/common.py
+++ b/sweagent/run/common.py
@@ -272,7 +272,7 @@ class BasicCLI:
             if module not in sys.modules:
                 __import__(module)
             type_ = getattr(sys.modules[module], name)
-            print(ConfigHelper().get_help(type_))
+            rich_print(ConfigHelper().get_help(type_))
             exit(0)
 
         # >>> Step 3: Load config files and merge them in a big nested data structure


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!
-->

#### Reference Issues/PRs
<!--
Example: "Fixes #1234", "See also #3456"
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### What does this implement/fix? Explain your changes.
<!--
Please include a brief explanation of how your solution
fixes the tagged issue(s), along with what files / entities have
been modified for this fix.
-->

The config help options were difficult to read because they weren't being printed with rich_print.

E.g.

```
> sweagent run --help_option sweagent.environment.swe_env.EnvironmentConfig

[green][bold]deployment[/bold][/green]: Deployment options.
    This config item can be one of the following things (run [green]--help_option <name>[/green] for more info):
    [green]swerex.deployment.config.LocalDeploymentConfig[/green]
    [green]swerex.deployment.config.DockerDeploymentConfig[/green]
    [green]swerex.deployment.config.ModalDeploymentConfig[/green]
    [green]swerex.deployment.config.FargateDeploymentConfig[/green]
    [green]swerex.deployment.config.RemoteDeploymentConfig[/green]
    [green]swerex.deployment.config.DummyDeploymentConfig[/green]

[green][bold]repo[/bold][/green]: Repository options.
    This config item can be one of the following things (run [green]--help_option <name>[/green] for more info):
    [green]sweagent.environment.repo.LocalRepoConfig[/green]
    [green]sweagent.environment.repo.GithubRepoConfig[/green]
    [green]sweagent.environment.repo.PreExistingRepoConfig[/green]
    [green]None[/green]

[green][bold]post_startup_commands[/bold][/green]: list[str]

[green][bold]post_startup_command_timeout[/bold][/green]: int

[green][bold]name[/bold][/green]: str
```

It makes reading the help message difficult.

Now it formats correctly.