### PR TITLE
Fix: Ensure state exists

### DIFF
--- a/sweagent/tools/tools.py
+++ b/sweagent/tools/tools.py
@@ -207,6 +207,7 @@ class ToolHandler:
         self.logger.info("Resetting tools")
         env.set_env_variables(self.config.env_variables)
         env.write_file("/root/.swe-agent-env", json.dumps(self.config.registry_variables))
+        env.write_file("/root/state.json", "{}")
         env.communicate(" && ".join(self._reset_commands), check="raise", timeout=self.config.install_timeout)
 
     async def _upload_bundles(self, env: SWEEnv) -> None:

--- a/tools/defaults/install.sh
+++ b/tools/defaults/install.sh
@@ -13,5 +13,3 @@ _write_env "CURRENT_FILE" "${CURRENT_FILE:-}"
 
 # install jq
 # apt-get update && apt-get install -y jq
-
-echo "{}" > /root/state.json

--- a/tools/edit_anthropic/install.sh
+++ b/tools/edit_anthropic/install.sh
@@ -1,3 +1,2 @@
 pip install 'tree-sitter==0.21.3'
 pip install 'tree-sitter-languages'
-echo "{}" > /root/state.json


### PR DESCRIPTION
Previously, if other toolbundles were specified, the state might not
have existed (we try and read it before we even execute the first
action)

In reference to #1048
