### PR TITLE
chore: Update to Python 3.13

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+  - package-ecosystem: "npm" # Update package.json
+    directory: "/sweagent/frontend"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.11", "3.12"]
+        python-version: ["3.11", "3.12", "3.13"]
     defaults:
       run:
         shell: bash -l {0}

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,13 +5,14 @@ WORKDIR /app
 
 # Install nodejs
 RUN apt update && \
-    apt install -y nodejs npm && \
-    apt-get clean && \
+    apt install -y nodejs npm curl && \
+    # Install Docker CLI using the official Docker installation script
+    curl -fsSL https://get.docker.com -o get-docker.sh && \
+    sh get-docker.sh && \
+    rm get-docker.sh && \
+    apt remove -y curl && \
+    apt autoremove -y && apt-get clean && \
     rm -rf /var/lib/apt/lists/*
-
-# Install Docker CLI using the official Docker installation script
-RUN curl -fsSL https://get.docker.com -o get-docker.sh && \
-    sh get-docker.sh
 
 # Copy the application code
 # Do this last to take advantage of the docker layer mechanism

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11
+FROM python:3.13-slim
 
 # Set the working directory
 WORKDIR /app

--- a/config/human.yaml
+++ b/config/human.yaml
@@ -1,6 +1,6 @@
 env:
   deployment:
-    image: python:3.11
+    image: python:3.13-slim
 agent:
   tools:
     env_variables:

--- a/config/human_demo.yaml
+++ b/config/human_demo.yaml
@@ -1,6 +1,6 @@
 env:
   deployment:
-    image: python:3.11
+    image: python:3.13-slim
 agent:
   templates:
     system_template: |-

--- a/docs/config/environments.md
+++ b/docs/config/environments.md
@@ -28,6 +28,6 @@ SHELL ["/bin/bash", "-c"]
 1. This is the base image that we're starting from
 2. Important to disable any interactive prompts when installing things
 
-Build it with `docker build -f tiny.Dockerfile -t swe-agent-tiny`.
+Build it with `docker build -f tiny.Dockerfile -t swe-agent-tiny .`.
 
 Now you can run it in the agent with `sweagent run --env.image swe-agent-tiny ...`

--- a/docs/config/environments.md
+++ b/docs/config/environments.md
@@ -1,12 +1,12 @@
 # Environments
 
-SWE-agent runs on docker images (`python:3.11` by default).
+SWE-agent runs on docker images (`python:3.13-slim` by default).
 If you are running on SWE-Benmch, every instance has a docker image that we pull from dockerhub.
 
 Here's an example of a simple custom docker environment:
 
 ```dockerfile title="tiny.Dockerfile"
-FROM python:3.11.10-bullseye  # (1)!
+FROM python:3.13-slim  # (1)!
 
 ARG DEBIAN_FRONTEND=noninteractive  # (2)!
 ENV TZ=Etc/UTC

--- a/docs/usage/batch_mode.md
+++ b/docs/usage/batch_mode.md
@@ -101,10 +101,10 @@ sweagent run-batch \
 Here'the simplest example of what such a file can look like
 
 ```yaml title="instances.yaml"
-- image_name: "python:3.11"  # (1)!
+- image_name: "python:3.13-slim"  # (1)!
   problem_statement: "A simple test problem"
   instance_id: "simple_test_problem"
-- image_name: "python:3.11"
+- image_name: "python:3.13-slim"
   problem_statement: "Another test problem"
   instance_id: "simple_test_problem_2"
 ```
@@ -154,7 +154,7 @@ where `instances.yaml` could look like this:
 - env:
     deployment:
       type: docker
-      image: python:3.11
+      image: python:3.13-slim
     repo:
         type: github
         github_url: "https://github.com/swe-agent/test-repo"
@@ -165,7 +165,7 @@ where `instances.yaml` could look like this:
 - env:
     deployment:
       type: docker
-      image: python:3.11
+      image: python:3.13-slim
   problem_statement:
     type: text
     text: "A simple test problem 2"

--- a/docs/usage/cl_tutorial.md
+++ b/docs/usage/cl_tutorial.md
@@ -33,7 +33,7 @@ python run.py \
   --agent.model.name=claude-3.5 \
   --env.repo.path=test-repo \
   --problem_statement.path=test-repo/problem_statements/1.md \
-  --env.deployment.image=python:3.12
+  --env.deployment.image=python:3.13-slim
 ```
 
 1. Make sure to add anthropic keys (or keys for your model provider) to the environment for this one!
@@ -47,7 +47,7 @@ For this, you first need to set up a modal account, install the necessary extra 
 python run.py \
   ...
   --env.deployment.type=modal \
-  --env.deployment.image=python:3.12
+  --env.deployment.image=python:3.13-slim
 ```
 
 !!! tip "All options"
@@ -218,7 +218,7 @@ Here's an example of a custom docker environment (it's also available in the rep
 
 <!-- There's a dockerfile annotation, but it somehow breaks annotations -->
 ```bash title="tiny_test.Dockerfile"
-FROM python:3.11.10-bullseye  # (1)!
+FROM python:3.13-slim  # (1)!
 
 ARG DEBIAN_FRONTEND=noninteractive  # (2)!
 ENV TZ=Etc/UTC  # (3)!

--- a/docs/usage/hello_world_output.txt
+++ b/docs/usage/hello_world_output.txt
@@ -7,8 +7,8 @@
 🔧 WARNING  demonstration_template is ignored when put_demos_in_history is True
 🏃 INFO     Starting environment
 🦖 DEBUG    Found free port 60661
-🦖 INFO     Starting container python3.11-0bc626f0-e72a-4faa-9b49-0323d0f1ab87 with image python:3.11 serving on port 60661
-🦖 DEBUG    Command: "docker run --rm -p 60661:8000 --name python3.11-0bc626f0-e72a-4faa-9b49-0323d0f1ab87 python:3.11 /bin/sh -c 'swerex-remote --auth-token
+🦖 INFO     Starting container python3.13-0bc626f0-e72a-4faa-9b49-0323d0f1ab87 with image python:3.13 serving on port 60661
+🦖 DEBUG    Command: "docker run --rm -p 60661:8000 --name python3.13-0bc626f0-e72a-4faa-9b49-0323d0f1ab87 python:3.13 /bin/sh -c 'swerex-remote --auth-token
             3f979423-c1fb-40f9-8a44-35256ee60f0a || (python3 -m pip install pipx && python3 -m pipx ensurepath && pipx run swe-rex --auth-token
             3f979423-c1fb-40f9-8a44-35256ee60f0a)'"
 🦖 INFO     Starting runtime at 60661

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ classifiers = [
   "License :: OSI Approved :: MIT License",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: 3 :: Only",
 ]
 

--- a/sweagent/environment/swe_env.py
+++ b/sweagent/environment/swe_env.py
@@ -25,7 +25,7 @@ class EnvironmentConfig(BaseModel):
     """Configure data sources and setup instructions for the environment in which we solve the tasks."""
 
     deployment: DeploymentConfig = Field(
-        default_factory=lambda: DockerDeploymentConfig(image="python:3.11", python_standalone_dir="/root"),
+        default_factory=lambda: DockerDeploymentConfig(image="python:3.13", python_standalone_dir="/root"),
         description="Deployment options.",
     )
     repo: RepoConfig | None = Field(

--- a/sweagent/run/batch_instances.py
+++ b/sweagent/run/batch_instances.py
@@ -184,7 +184,7 @@ class InstancesFromFile(BaseModel, AbstractInstanceSource):
     """Shuffle the instances (before filtering and slicing)."""
 
     deployment: DeploymentConfig = Field(
-        default_factory=lambda: DockerDeploymentConfig(image="python:3.11"),
+        default_factory=lambda: DockerDeploymentConfig(image="python:3.13-slim"),
         description="Deployment options.",
     )
     """Note that the image_name option is overwritten by the images specified in the task instances."""
@@ -223,7 +223,7 @@ class InstancesFromHuggingFace(BaseModel, AbstractInstanceSource):
     """Shuffle the instances (before filtering and slicing)."""
 
     deployment: DeploymentConfig = Field(
-        default_factory=lambda: DockerDeploymentConfig(image="python:3.11"),
+        default_factory=lambda: DockerDeploymentConfig(image="python:3.13-slim"),
     )
     """Deployment configuration. Note that the `image_name` option is overwritten by the images specified in the task instances.
     """
@@ -252,7 +252,7 @@ class SWEBenchInstances(BaseModel, AbstractInstanceSource):
     split: Literal["dev", "test"] = "dev"
 
     deployment: DeploymentConfig = Field(
-        default_factory=lambda: DockerDeploymentConfig(image="python:3.11"),
+        default_factory=lambda: DockerDeploymentConfig(image="python:3.13-slim"),
     )
     """Deployment configuration. Note that the image_name option is overwritten by the images specified in the task instances.
     """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -82,7 +82,7 @@ def test_env_args(
     clone_cmd = ["git", "clone", "https://github.com/swe-agent/test-repo", str(local_repo_path)]
     subprocess.run(clone_cmd, check=True)
     test_env_args = EnvironmentConfig(
-        deployment=DockerDeploymentConfig(image="python:3.11"),
+        deployment=DockerDeploymentConfig(image="python:3.13-slim"),
         repo=LocalRepoConfig(path=Path(local_repo_path)),
     )
     yield test_env_args

--- a/tests/test_batch_instance.py
+++ b/tests/test_batch_instance.py
@@ -11,7 +11,7 @@ from sweagent.run.batch_instances import BatchInstance, SimpleBatchInstance, SWE
 def test_simple_batch_from_swe_bench_to_full_batch_instance(test_data_sources_path):
     sb_instance = json.loads((test_data_sources_path / "swe-bench-dev-easy.json").read_text())[0]
     instance = SimpleBatchInstance.from_swe_bench(sb_instance).to_full_batch_instance(
-        DockerDeploymentConfig(image="python:3.11")
+        DockerDeploymentConfig(image="python:3.13-slim")
     )
     assert isinstance(instance.env.repo, PreExistingRepoConfig)
     assert instance.env.repo.repo_name == "testbed"

--- a/tests/test_data/data_sources/expert_instances.yaml
+++ b/tests/test_data/data_sources/expert_instances.yaml
@@ -1,7 +1,7 @@
 - env:
     deployment:
       type: docker
-      image: python:3.11
+      image: python:3.13-slim
   problem_statement:
     type: text
     text: "A simple test problem"
@@ -9,7 +9,7 @@
 - env:
     deployment:
       type: docker
-      image: python:3.11
+      image: python:3.13-slim
   problem_statement:
     type: text
     text: "A simple test problem 2"

--- a/tests/test_data/data_sources/simple_instances.yaml
+++ b/tests/test_data/data_sources/simple_instances.yaml
@@ -1,3 +1,3 @@
-- image_name: "python:3.11"
+- image_name: "python:3.13-slim"
   problem_statement: "A simple test problem"
   id: "simple_test_problem"

--- a/tests/test_run_replay.py
+++ b/tests/test_run_replay.py
@@ -12,7 +12,7 @@ from sweagent.run.run_replay import RunReplay, RunReplayConfig
 def rr_config(swe_agent_test_repo_traj, tmp_path, swe_agent_test_repo_clone):
     return RunReplayConfig(
         traj_path=swe_agent_test_repo_traj,
-        deployment=DockerDeploymentConfig(image="python:3.11"),
+        deployment=DockerDeploymentConfig(image="python:3.13-slim"),
         output_dir=tmp_path,
     )
 


### PR DESCRIPTION
#### Updates
- Update image references to python:3.13-slim
- Add Python 3.13 to pytest
- Let Dependabot update NodeJS

#### Fixes
- curl isn't installed by default in Debian (`FROM python`)
- `docker build` example was missing the context (first positional argument)

#### Documentation errors
Markdown example `sweagent run --env.image swe-agent-tiny` results in
> SettingsError
> error parsing CLI: unrecognized arguments: --env.image swe-agent-tiny

pydoc example `--env.docker.image` doesn't work either.

#### TODO
- Dependabot should also update Dockerfiles and docker-compose
- Docker base images `ubuntu:14.04` haven't been built for three years
- release_dockerhub.sh references `-f docker/swe.Dockerfile` which doesn't exist
- pytest coverage only runs for `if: matrix.python-version == '3.11'`, maybe that could be 3.13 too?

