### PR TITLE
Fix spelling of 'agent' in hello world

### DIFF
--- a/docs/usage/hello_world.md
+++ b/docs/usage/hello_world.md
@@ -27,7 +27,7 @@ sweagent run \
 ```
 
 The example above uses the `Claude 3.5 Sonnet` model from Anthropic. Alternatively, you can for example use `GPT-4o` (from OpenAI)
-by setting `--angent.model.name=gpt-4o`.
+by setting `--agent.model.name=gpt-4o`.
 In order to use it, you need to add your keys to the environment:
 
 ```bash


### PR DESCRIPTION
It's just a single character doc fix in the hello world doc