### PR TITLE
[EnIGMA] Fix swebench version to 2.0 in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ openai>=1.0
 pandas
 rich
 ruamel.yaml
-swebench>=2.0.0
+swebench>=2.0.0,<3
 tenacity
 unidiff
 simple-parsing


### PR DESCRIPTION
When I follows [EnIGMA usage tutorial](https://swe-agent.com/0.7/usage/enigma/), I got the following error:

```bash
> python run.py \
  --model_name gpt4 \
  --ctf \
  --image_name sweagent/enigma:latest \
  --data_path ../NYU_CTF_Bench/test/2018/CSAW-Finals/misc/leaked_flag/challenge.json \
  --repo_path ../NYU_CTF_Bench/test/2018/CSAW-Finals/misc/leaked_flag/ \
  --config_file config/default_ctf.yaml \
  --per_instance_cost_limit 2.00

ERROR    keys.cfg not found in /home/run/SWE-agent/sweagent
Traceback (most recent call last):
  File "/home/run/SWE-agent/run.py", line 44, in <module>
    from sweagent.agent.agents import Agent, AgentArguments
  File "/home/run/SWE-agent/sweagent/agent/agents.py", line 28, in <module>
    from sweagent.agent.summarizer import SummarizerConfig
  File "/home/run/SWE-agent/sweagent/agent/summarizer.py", line 14, in <module>
    from sweagent.environment.swe_env import SWEEnv
  File "/home/run/SWE-agent/sweagent/environment/swe_env.py", line 24, in <module>
    from swebench.harness.utils import get_environment_yml, get_requirements
ImportError: cannot import name 'get_environment_yml' from 'swebench.harness.utils' (/home/run/anaconda3/envs/enigma/lib/python3.12/site-packages/swebench/harness/utils.py)
```

This is because when installing EnIGMA in branch v0.7, `requirements.txt` says `swebench>=2.0.0`, which at the time of writing this, it resolve to install `swebench` version `3.0.17` instead.

Changing it to `swebench>=2.0.0,<3` fixed the problem, which resolve to `swebench` version `2.1.8`.