### PR TITLE
Fix trajectory messages to reflect what LLM actually saw

### DIFF
--- a/sweagent/types.py
+++ b/sweagent/types.py
@@ -27,6 +27,9 @@ class StepOutput(BaseModel):
     """State of the environment at the end of the step"""
     extra_info: dict[str, Any] = {}
 
+    # The exact list of messages that were provided to the language model for this step.
+    input_messages: list[dict[str, Any]] = []
+
     def to_template_format_dict(self) -> dict[str, str | int | float | bool | None]:
         """Used for formatting (error) prompt templates"""
         out = {}


### PR DESCRIPTION
## Fix: Ensure Trajectory Messages Accurately Reflect LLM Input/Output

**Problem:**

Previously, the `messages` field saved within each `TrajectoryStep` in the `.traj` file did not accurately represent the input the language model received for that specific step.

This occurred because:
1.  The `DefaultAgent.step` method first called the LLM with `self.messages` (which applies history processors).
2.  It then updated the raw `self.history` with the LLM's response (assistant message) and the resulting observation (user/tool message).
3.  Finally, it called `self.add_step_to_trajectory`, which accessed `self.messages` *again*. This re-applied the history processors to the *updated* history, leading to a different set of messages being saved than what the LLM originally saw (e.g., with `LastNObservations`, the observation from the *current* step was included, while the one actually sent to the LLM was potentially omitted).

**Solution:**

This PR introduces the following changes to `sweagent/agent/agents.py` to fix this discrepancy and improve usability for fine-tuning:

1.  **Capture LLM Input:** In `DefaultAgent.step`, the result of `self.messages` is now captured *before* the call to `forward_with_handling`. This variable (`messages_for_llm`) accurately stores the processed messages sent to the LLM.
2.  **Store Full Turn in Trajectory:**
    *   After `add_step_to_history` adds the raw assistant response and user/tool observation to `self.history`, a new list `messages_for_trajectory` is created.
    *   This list combines the captured `messages_for_llm` with the last two entries from the raw `self.history` to further facilitate fine-tuning later.
    *   `add_step_to_trajectory` is modified to accept this list and save it in the `TrajectoryStep`.

**Outcome:**

The `messages` field in each trajectory step now accurately represents the full conversation turn for that step:
- The processed input messages exactly as seen by the LLM.
- The raw, unprocessed assistant message (LLM response).
- The raw, unprocessed user/tool message (observation).

This provides a correct record of the interaction for analysis and makes the trajectory format more convenient for fine-tuning, as the input and target completion are readily available within the step's `messages` without needing to reconstruct the state or worry about the effect of history processors on the output messages.

## Reproducing the Original Issue

To observe the discrepancy in the trajectory messages before this fix, follow these steps:

1.  **Modify Configuration (`config/function_calling.yaml`):**
    *   Set the `LastNObservations` history processor to keep only the last observation by changing `n` to `1`:
        ```yaml
        history_processors:
          - type: last_n_observations
            n: 1 # <-- Change this from the default
        ```
    *   For simplicity and faster reproduction, remove or comment out all the sections related to demonstrations within the `templates` block.

2.  **Run SWE-agent:** Execute the following command from the root of the repository:
    ```bash
    sweagent run --config ./config/function_calling.yaml \
      --agent.model.name=gpt-4o \
      --agent.model.per_instance_cost_limit=2.00 \
      --env.repo.github_url=https://github.com/SWE-agent/test-repo \
      --problem_statement.github_url=https://github.com/SWE-agent/test-repo/issues/1 \
      --output_dir=./generated_trajectories
    ```

3.  **Inspect Trajectory:**
    *   Once the run completes, open the generated `.traj` file located in `./generated_trajectories/`. The filename will correspond to the issue ID (e.g., `test-repo__test-repo-1.traj`).
    *   Examine the `trajectory` list within the JSON structure. Look specifically at the `messages` field of the *last* step in the trajectory.
    *   **Observation (Original Bug):** You would notice that the last message in this `messages` list is the user/tool observation corresponding to the *current* step. Because `LastNObservations` was set to `n=1` and applied *after* the history was updated, the previous observation, which is the one that was *actually* sent to the LLM (from the *previous* step), is omitted. This `messages` list does not accurately reflect the input the LLM received for this final step.