### PR TITLE
BREAKING CHANGE: messages -> query field in traj

### DIFF
--- a/docs/usage/cli.md
+++ b/docs/usage/cli.md
@@ -13,4 +13,3 @@ Here's a quick overview:
 * `sweagent inspector` or `sweagent I`: Open the web-based inspector ([more information](inspector.md)).
 * `sweagent merge-preds`: Merge multiple prediction files into a single file.
 * `sweagent traj-to-demo`: Convert a trajectory file to an easy to edit demo file ([more information on demonstrations](../config/demonstrations.md)).
-

--- a/docs/usage/trajectories.md
+++ b/docs/usage/trajectories.md
@@ -10,13 +10,24 @@ Under the `trajectory` key, you can see information for every step of the agent.
 
 ```json
 {
-  "action": "ls -F\n",
-  "observation": "AUTHORS.rst\nCHANGELOG.rst\nCODE_OF_CONDUCT.md...",
+  # This is the output of the LM
   "response": "We are indeed seeing the same output as the issue. The issue suggests that we should look at line 1474 of the `fields.py`...",
-  "state": "{\"open_file\": \"/marshmallow-code__marshmallow/reproduce.py\", \"working_dir\": \"/marshmallow-code__marshmallow\"}\n",
+  # We then parse it into thoughts and actions
   "thought": "We are indeed seeing the same output as the issue. The issue suggests that we should look at line 1474 of the `fields.py`..."
+  "action": "ls -F\n",
+  # And execute the action, resulting in the output
+  "observation": "AUTHORS.rst\nCHANGELOG.rst\nCODE_OF_CONDUCT.md...",
+  # In addition, after the action was executed, state can be extracted from the environment
+  "state": "{\"open_file\": \"/marshmallow-code__marshmallow/reproduce.py\", \"working_dir\": \"/marshmallow-code__marshmallow\"}\n",
+  # For debugging, we also keep all messages that were shown to the LM
+  "query": [{"role": "system", "content": "You are a helpful assistant ..."}, ...]
 },
 ```
+
+!!! warning "Query and message field"
+    Prior to SWE-agent 1.1.0, we had a `message` field which corresponded (approximately) to the input
+    for the LM for the _next_ step. This was replaced with `query`, which shows the exact input
+    at the current step.
 
 Here's a full example:
 

--- a/sweagent/agent/agents.py
+++ b/sweagent/agent/agents.py
@@ -972,6 +972,7 @@ class DefaultAgent(AbstractAgent):
         # attributes (e.g., if we want to requery the model for a bash syntax error, we
         # need to have the previous model output to format the requery template)
         step = StepOutput()
+        step.query = copy.deepcopy(history)
         try:
             # Forward model and get actions
             self._chook.on_model_query(messages=history, agent=self.name)
@@ -1171,7 +1172,7 @@ class DefaultAgent(AbstractAgent):
                 "thought": step.thought,
                 "execution_time": step.execution_time,
                 "state": step.state,
-                "messages": self.messages,
+                "query": step.query,
                 "extra_info": step.extra_info,
             },
         )

--- a/sweagent/inspector/fileViewer.js
+++ b/sweagent/inspector/fileViewer.js
@@ -33,7 +33,18 @@ function fetchFiles() {
 
 function createTrajectoryItem(item, index) {
   const elementId = `trajectoryItem${index}`;
-  const hasMessages = item.messages && item.messages.length > 0;
+
+  // Check for old format and log a warning
+  const isOldFormat = item.messages && !item.query;
+  if (isOldFormat) {
+    console.log(
+      `Found old format using 'messages' instead of 'query' in item ${index}`,
+    );
+    // Migrate old format to new format
+    item.query = item.messages;
+  }
+
+  const hasMessages = item.query && item.query.length > 0;
 
   const escapeHtml = (text) => {
     if (!text) {
@@ -71,7 +82,7 @@ function createTrajectoryItem(item, index) {
   };
 
   const messagesContent = hasMessages
-    ? item.messages
+    ? item.query
         .map((msg, msgIndex) => {
           let content = `----Item ${msgIndex}-----\n`;
           content += `role: ${msg.role}\n`;

--- a/sweagent/types.py
+++ b/sweagent/types.py
@@ -13,6 +13,7 @@ from typing_extensions import TypedDict
 
 
 class StepOutput(BaseModel):
+    query: list[dict] = [{}]
     thought: str = ""
     action: str = ""
     output: str = ""
@@ -45,7 +46,7 @@ class TrajectoryStep(TypedDict):
     state: dict[str, str]
     thought: str
     execution_time: float
-    messages: list[dict[str, Any]]
+    query: list[dict[str, Any]]
     extra_info: dict[str, Any]
 
 


### PR DESCRIPTION
The query attribute now corresponds to the exact input for the LM at the current step.
Preciously, the messages attribute for step i was essentially the input for step i+1 in all but rare cases (requeries, etc.). The query attribute now supersedes the messages attribute.
