### PR TITLE
FIX: Use correct local model tokenizer for computing token consumption

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,6 @@ dependencies = [
     "swe-rex>=1.2.0",
     "tabulate",
     "textual>=1.0.0",
-    "transformers",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ dependencies = [
     "swe-rex>=1.2.0",
     "tabulate",
     "textual>=1.0.0",
+    "transformers",
 ]
 
 [project.scripts]

--- a/sweagent/agent/models.py
+++ b/sweagent/agent/models.py
@@ -24,7 +24,6 @@ from tenacity import (
     stop_after_attempt,
     wait_random_exponential,
 )
-from transformers import AutoTokenizer
 
 from sweagent import REPO_ROOT
 from sweagent.exceptions import (
@@ -599,6 +598,7 @@ class LiteLLMModel(AbstractModel):
         self.lm_provider = litellm.model_cost.get(self.config.name, {}).get("litellm_provider", self.config.name)
         if self.config.per_instance_cost_limit == 0 and self.config.total_cost_limit == 0:  # Local model
             if "/" in self.lm_provider:
+                from transformers import AutoTokenizer
                 self.custom_tokenizer = {}
                 self.custom_tokenizer["provider"] = self.lm_provider.split("/")[0]
 

--- a/sweagent/agent/models.py
+++ b/sweagent/agent/models.py
@@ -599,6 +599,7 @@ class LiteLLMModel(AbstractModel):
         if self.config.per_instance_cost_limit == 0 and self.config.total_cost_limit == 0:  # Local model
             if "/" in self.lm_provider:
                 from transformers import AutoTokenizer
+
                 self.custom_tokenizer = {}
                 self.custom_tokenizer["provider"] = self.lm_provider.split("/")[0]
 

--- a/sweagent/agent/models.py
+++ b/sweagent/agent/models.py
@@ -11,6 +11,7 @@ from abc import ABC, abstractmethod
 from pathlib import Path
 from threading import Lock
 from typing import Annotated, Any, Literal
+from transformers import AutoTokenizer
 
 import litellm
 import litellm.types.utils
@@ -561,6 +562,7 @@ class LiteLLMModel(AbstractModel):
         self.stats = InstanceStats()
         self.tools = tools
         self.logger = get_logger("swea-lm", emoji="🤖")
+        self.custom_tokenizer = None
 
         if tools.use_function_calling:
             if not litellm.utils.supports_function_calling(model=self.config.name):
@@ -594,7 +596,22 @@ class LiteLLMModel(AbstractModel):
                     "completion_kwargs to {'extra_headers': {'anthropic-beta': 'output-128k-2025-02-19'}}."
                 )
 
-        self.lm_provider = litellm.model_cost.get(self.config.name, {}).get("litellm_provider")
+        self.lm_provider = litellm.model_cost.get(self.config.name, {}).get("litellm_provider", self.config.name)
+        if self.config.per_instance_cost_limit == 0 and self.config.total_cost_limit == 0: # Local model
+            if '/' in self.lm_provider:
+                self.custom_tokenizer = {}
+                self.custom_tokenizer['provider'] = self.lm_provider.split('/')[0]
+
+                if self.custom_tokenizer['provider'] not in litellm.provider_list:
+                    self.logger.warning(f"Local model {self.lm_provider} not found in LiteLLM provider list. Using default tokenizer.")
+                    self.custom_tokenizer = None
+                else:
+                    self.custom_tokenizer['identifier'] = '/'.join(self.lm_provider.split('/')[1:])
+                    self.custom_tokenizer['type'] = "huggingface_tokenizer"
+                    # Use backend tokenizer as workaround for litellm HF tokenizer bug
+                    self.custom_tokenizer['tokenizer'] = AutoTokenizer.from_pretrained(self.custom_tokenizer['identifier']).backend_tokenizer
+            else:
+                self.logger.warning(f"Local model identifier {self.lm_provider} has an unknown format. Using default tokenizer.")
 
     @property
     def instance_cost_limit(self) -> float:
@@ -657,7 +674,9 @@ class LiteLLMModel(AbstractModel):
         for message in messages_no_cache_control:
             if "cache_control" in message:
                 del message["cache_control"]
-        input_tokens: int = litellm.utils.token_counter(messages=messages_no_cache_control, model=self.config.name)
+        input_tokens: int = litellm.utils.token_counter(messages=messages_no_cache_control, 
+                                                        model=self.custom_tokenizer['identifier'] if self.custom_tokenizer else self.config.name,
+                                                        custom_tokenizer=self.custom_tokenizer)
         if self.model_max_input_tokens is None:
             msg = (
                 f"No max input tokens found for model {self.config.name!r}. "
@@ -718,7 +737,9 @@ class LiteLLMModel(AbstractModel):
         output_tokens = 0
         for i in range(n_choices):
             output = choices[i].message.content or ""
-            output_tokens += litellm.utils.token_counter(text=output, model=self.config.name)
+            output_tokens += litellm.utils.token_counter(text=output, 
+                                                        model=self.custom_tokenizer['identifier'] if self.custom_tokenizer else self.config.name,
+                                                        custom_tokenizer=self.custom_tokenizer)
             output_dict = {"message": output}
             if self.tools.use_function_calling:
                 if response.choices[i].message.tool_calls:  # type: ignore


### PR DESCRIPTION
## Issue this PR addresses
SWE-agent tracks the token consumption of the agent using the LiteLLM `token_counter`. However, this does not work as expected for local models.

### Expected
The LiteLLM functionality for tokenizing and counting tokens with the model specific tokenizer is utilized.
### Actual
The `token_counter` is invoked as is. This results in using the OpenAI tokenizer to count tokens (default fallback), resulting in potentially incorrect token counts.
### Why this is an issue?
As SWE-agent is a project that is popular in the research community, and this community is moving towards training local models. In an effort of scientific rigor, we should use accurate token consumption statistics.

## Changes this PR introduces
If the configuration is in line with that of a local model (cost limits are 0), we set up the model-specific tokenizer using HF `transformers` and `AutoTokenizer`. Due to a bug in LiteLLM, we pass the `backend_tokenizer`. We update the `token_counter` to use this `custom_tokenizer` if available.