### PR TITLE
Fix: Correctly format commit message for PR creation

### DIFF
--- a/sweagent/run/hooks/open_pr.py
+++ b/sweagent/run/hooks/open_pr.py
@@ -50,8 +50,8 @@ def open_pr(*, logger, token, env: SWEEnv, github_url, trajectory, _dry_run: boo
     env.communicate(input="git add .", error_msg="Failed to add commits", timeout=10, check="raise")
     dry_run_flag = "--allow-empty" if _dry_run else ""
     commit_msg = [
-        shlex.quote("Fix: {issue.title}"),
-        shlex.quote("Closes #{issue.number}"),
+        shlex.quote(f"Fix: {issue.title}"),
+        shlex.quote(f"Closes #{issue.number}"),
     ]
     out = env.communicate(
         input=f"git commit -m {commit_msg[0]} -m  {commit_msg[1]} {dry_run_flag}",


### PR DESCRIPTION
The commit message by the agent does not formatted properly
![image](https://github.com/user-attachments/assets/4d40e248-2761-47e1-a091-26d53bde1179)

<!--
Thanks for contributing a pull request!
-->

#### Reference Issues/PRs
<!--
Example: "Fixes #1234", "See also #3456"
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### What does this implement/fix? Explain your changes.
<!--
Please include a brief explanation of how your solution
fixes the tagged issue(s), along with what files / entities have
been modified for this fix.
-->

This pull request includes a small change to the `open_pr` function in `sweagent/run/hooks/open_pr.py`. The change updates the string formatting for commit messages to use f-strings for formating the message properly