### PR TITLE
Fix: Use repository's default branch for PR base instead of hardcoded…

### DIFF
--- a/sweagent/run/hooks/open_pr.py
+++ b/sweagent/run/hooks/open_pr.py
@@ -97,13 +97,14 @@ def open_pr(*, logger, token, env: SWEEnv, github_url, trajectory, _dry_run: boo
     )
     body += "\n\n" + format_trajectory_markdown(trajectory, char_limit=60_000)
     api = GhApi(token=token)
+    default_branch = api.repos.get(owner, repo).default_branch
     if not _dry_run:
         args = dict(
             owner=owner,
             repo=repo,
             title=f"SWE-agent[bot] PR to fix: {issue.title}",
             head=head,
-            base="main",
+            base=default_branch,
             body=body,
             draft=True,
         )


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!
-->

#### Reference Issues/PRs
<!--
Example: "Fixes #1234", "See also #3456"
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #1158 

#### What does this implement/fix? Explain your changes.
<!--
Please include a brief explanation of how your solution
fixes the tagged issue(s), along with what files / entities have
been modified for this fix.
-->
This pull request updates the `open_pr` function in `sweagent/run/hooks/open_pr.py` to dynamically set the base branch for pull requests to the repository's default branch instead of hardcoding it to "main."
