### PR TITLE
Fixes #1166: strip incorrect for XML function calling

### DIFF
--- a/sweagent/tools/parsing.py
+++ b/sweagent/tools/parsing.py
@@ -276,7 +276,11 @@ class XMLFunctionCallingParser(AbstractParseFunction, BaseModel):
             msg = f"Command '{fn_name}' not found in list of available commands."
             raise FormatError(msg)
 
-        params_dict = {param[0]: param[1].strip() for param in re.findall(FN_PARAM_REGEX_PATTERN, fn_body, re.DOTALL)}
+        params_dict = {
+            param[0]: re.sub(r"^\n|\n$", "", param[1])
+            for param in re.findall(FN_PARAM_REGEX_PATTERN, fn_body, re.DOTALL)
+        }
+
         if "view_range" in params_dict:
             # Check that value is format as [x, y]
             v = params_dict["view_range"]


### PR DESCRIPTION
The `XMLFunctionCallingParser` is striping arguments from the models when converting to tool call, which can lead into issues when using old_str/new_str tools, as the fields would be modified. 

For instance, if the model wants to replace \n   a, that would actually be seen as a. 
This PR uses re.sub(r"^\n|\n$", "", text) removes at most one newline at begging and end of the field, such that 
```
<parameter=example_parameter_2>
This is the value for the second parameter
that can span
multiple lines
</parameter>
</function>
```
gives as param 
```
This is the value for the second parameter
that can span
multiple lines
```