### PR TITLE
Fix: Ignore missing treesitter for very old python

### DIFF
--- a/tools/edit_anthropic/install.sh
+++ b/tools/edit_anthropic/install.sh
@@ -1,2 +1,3 @@
-pip install 'tree-sitter==0.21.3'
-pip install 'tree-sitter-languages'
+# Ignore failures, see https://github.com/SWE-agent/SWE-agent/issues/1179
+pip install 'tree-sitter==0.21.3' || true
+pip install 'tree-sitter-languages' || true


### PR DESCRIPTION
Closes #1179
