### PR TITLE
Fix: WindowedFile bug preventing last line of a file from being displayed

### DIFF
--- a/tests/tools/test_default_utils.py
+++ b/tests/tools/test_default_utils.py
@@ -72,6 +72,8 @@ def test_windowed_file_goto(windowed_file):
     wfile.goto(50, mode="top")
     # first line is 50 - 10//4 = 47
     assert wfile.line_range[0] == 47
+    wfile.goto(100, mode="top")
+    assert wfile.line_range[1] == 99
 
 
 def test_windowed_file_scroll(windowed_file):
@@ -85,6 +87,8 @@ def test_windowed_file_scroll(windowed_file):
     wfile.scroll(-100)
     # Can't go lower than the middle of the lowest window
     assert wfile.first_line == 0
+    wfile.scroll(100)
+    assert wfile.line_range[1] == 99
 
 
 # def test_goto_command(windowed_file):

--- a/tools/windowed/lib/windowed_file.py
+++ b/tools/windowed/lib/windowed_file.py
@@ -121,7 +121,7 @@ class WindowedFile:
     def first_line(self, value: Union[int, float]):
         self._original_first_line = self.first_line
         value = int(value)
-        self._first_line = max(0, min(value, self.n_lines - 1 - self.window))
+        self._first_line = max(0, min(value, self.n_lines - self.window))
         registry["FIRST_LINE"] = self.first_line
 
     @property


### PR DESCRIPTION
## Issue solved by this PR

WindowedFile never displays the last line of a file if the total number of lines exceeds the `WINDOW` size.

The bug originates from the `first_line` setter  in `tools/windowed/lib/windowed_file.py`:
```python
self._first_line = max(0, min(value, self.n_lines - 1 - self.window))
```

The maximum possible value for `first_line` is `self.n_lines - 1 - self.window`, which is too small by 1. 

Consider a 200-line file with a 100-line window size. The maximum possible value of `first_line` is 200 - 1 - 100 = 99. This corresponds to the window 99:198, meaning that line 199 is never displayed.

## Changes introduced by this PR

This PR fixes the bug by removing the `- 1` in the `first_line` setter:
```python
self._first_line = max(0, min(value, self.n_lines - self.window))
```

It also makes minor additions to `tests/tools/test_default_utils.py` to verify that the last line of `windowed_file` can be displayed when navigating to the end with either `goto` or `scroll`.