### PR TITLE
Move observation truncation to jinja template next_step_truncated_obs…

### DIFF
--- a/sweagent/agent/agents.py
+++ b/sweagent/agent/agents.py
@@ -67,7 +67,7 @@ class TemplateConfig(BaseModel):
     next_step_template: str = "Observation: {{observation}}"
 
     next_step_truncated_observation_template: str = (
-        "Observation: {{observation}}<response clipped>"
+        "Observation: {{observation[:max_observation_length]}}<response clipped>"
         "<NOTE>Observations should not exceeded {{max_observation_length}} characters. "
         "{{elided_chars}} characters were elided. Please try a different command that produces less output "
         "or use head/tail/grep/redirect the output to a file. Do not use interactive pagers.</NOTE>"
@@ -716,7 +716,6 @@ class DefaultAgent(AbstractAgent):
         elif len(step.observation) > self.templates.max_observation_length:
             templates = [self.templates.next_step_truncated_observation_template]
             elided_chars = len(step.observation) - self.templates.max_observation_length
-            step.observation = step.observation[: self.templates.max_observation_length]
         else:
             # Show standard output template if there is observation content
             templates = [self.templates.next_step_template]


### PR DESCRIPTION
…ervation_template instead of manual truncation

<!--
Thanks for contributing a pull request!
-->

#### Reference Issues/PRs
<!--
Example: "Fixes #1234", "See also #3456"
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
n/a

#### What does this implement/fix? Explain your changes.
<!--
Please include a brief explanation of how your solution
fixes the tagged issue(s), along with what files / entities have
been modified for this fix.
-->
This moves the clipping by max_observation_length into the jinja template next_step_truncated_observation_template instead of manually clipping, as is done currently at https://github.com/SWE-agent/SWE-agent/blob/61e5d0628405a6a90cace1f3073b0619c9e536a0/sweagent/agent/agents.py#L719

We may want to also discuss general usage of config variables and jinja in templates.