### PR TITLE
Docs: Fix Claude model name typos

### DIFF
--- a/docs/installation/keys.md
+++ b/docs/installation/keys.md
@@ -44,7 +44,7 @@ Here are a few options for `--agent.model.name`:
 
 | Model | API key | Comment |
 | ----- | ------- | ------- |
-| `claude-sonnet-4-20250514)` | `ANTHROPIC_API_KEY` | Our recommended model |
+| `claude-sonnet-4-20250514` | `ANTHROPIC_API_KEY` | Our recommended model |
 | `gpt-4o` | `OPENAI_API_KEY` | |
 | `o1-preview` | `OPENAI_API_KEY` | You might need to set temperature and sampling to the supported values. |
 

--- a/docs/usage/hello_world.md
+++ b/docs/usage/hello_world.md
@@ -20,13 +20,13 @@ Let's start with an absolutely trivial example and solve an issue about a simple
 
 ```bash
 sweagent run \
-  --agent.model.name=claude-sonnet-4-20250514) \
+  --agent.model.name=claude-sonnet-4-20250514 \
   --agent.model.per_instance_cost_limit=2.00 \
   --env.repo.github_url=https://github.com/SWE-agent/test-repo \
   --problem_statement.github_url=https://github.com/SWE-agent/test-repo/issues/1
 ```
 
-The example above uses the `Claude 3.5 Sonnet` model from Anthropic. Alternatively, you can for example use `GPT-4o` (from OpenAI)
+The example above uses the `Claude Sonnet 4` model from Anthropic. Alternatively, you can for example use `GPT-4o` (from OpenAI)
 by setting `--agent.model.name=gpt-4o`.
 In order to use it, you need to add your keys to the environment:
 


### PR DESCRIPTION
#### Reference Issues/PRs

N/A

#### What does this implement/fix? Explain your changes.

This PR fixes typos in the Claude model name references in the documentation:

- Fixed `claude-sonnet-4-20250514)` → `claude-sonnet-4-20250514` (removed extra parenthesis) in docs/installation/keys.md
- Fixed `claude-sonnet-4-20250514)` → `claude-sonnet-4-20250514` (removed extra parenthesis) in docs/usage/hello_world.md
- Updated model description from "Claude 3.5 Sonnet" to "Claude Sonnet 4" to match the actual model name

These fixes ensure the documentation has the correct model name format and removes syntax errors in command examples.