### PR TITLE
Doc: Fix typos and URL corrections in developer documentation

### DIFF
--- a/docs/dev/contribute.md
+++ b/docs/dev/contribute.md
@@ -34,7 +34,7 @@ pre-commit install
     Most problems (including formatting) will be automatically fixed.
     Therefore, if `pre-commit`/`git commit` fails on its first run, simply try running it a second time.
 
-    Some more autofixes can be enabled with the `--unsafe-fixes` option from [`ruff`](https://github.com/charliermarsh/ruff):
+    Some more autofixes can be enabled with the `--unsafe-fixes` option from [`ruff`](https://github.com/astral-sh/ruff):
 
     ```bash
     pipx run ruff check --fix --unsafe-fixes
@@ -115,7 +115,7 @@ to see all debug output from the agent.
   However, if you make the behavior optional without complicating SWE-agent (for example by providing new [commands](../config/tools.md)),
   we might be less strict.
 * Please add simple unit tests or integration tests wherever possible. Take a look in the [tests directory](https://github.com/SWE-agent/SWE-agent/tree/main/tests)
-  for inspiration. We emphasize simple easy-tow-rite tests that get a lot of coverage.
+  for inspiration. We emphasize simple easy-to-write tests that get a lot of coverage.
 
 [gfi]: https://github.com/SWE-agent/SWE-agent/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3A%22%F0%9F%91%8B+good+first+issue%22+
 [help_wanted]: https://github.com/SWE-agent/SWE-agent/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3A%22%F0%9F%99%8F+help+wanted%22

--- a/docs/dev/formatting_conflicts.md
+++ b/docs/dev/formatting_conflicts.md
@@ -28,10 +28,10 @@ export FEATURE_BRANCH="main"
 Next we create a copy of this branch (so we don't further modify it):
 
 ```bash
-git branch "${FEATURE_BRANCH}" "${FEATURE_BRANCH}_REBASED"
+git branch "${FEATURE_BRANCH}_REBASED" "${FEATURE_BRANCH}"
 ```
 
-And now comes the tricky bit: We rebase your changes on top of `upstream/mean`, while applying
+And now comes the tricky bit: We rebase your changes on top of `upstream/main`, while applying
 the formatting fixes at every step:
 
 ```bash


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

This PR fixes typos and URL corrections in the developer documentation:

**Files modified:**
- `docs/dev/contribute.md` - Fixed typo "easy-tow-rite" → "easy-to-write" and updated ruff GitHub URL from old repository to current one
- `docs/dev/formatting_conflicts.md` - Fixed typo "upstream/mean" → "upstream/main" and corrected git branch command parameter order

**Changes:**
- Updated ruff repository URL from `charliermarsh/ruff` to `astral-sh/ruff` (the project moved organizations)
- Fixed typo in test writing guidance: "easy-tow-rite" → "easy-to-write"
- Corrected git branch creation command parameter order
- Fixed reference to upstream branch from "mean" to "main"

These are documentation quality improvements that enhance readability and ensure accurate instructions for contributors