### PR TITLE
Doc: Improve reference documentation with descriptions and fix links

### DIFF
--- a/docs/reference/agent_config.md
+++ b/docs/reference/agent_config.md
@@ -13,11 +13,14 @@ It might be easiest to simply look at some of our example configurations in the 
 ```
 </details>
 
-Currently, there are two main agent classes:
+Currently, there are three main agent classes:
 
 * `DefaultAgentConfig`: This is the default agent.
 * `RetryAgentConfig`: A "meta agent" that instantiates multiple agents for multiple attempts and then picks the best solution.
+* `ShellAgentConfig`: An agent that provides shell-based interaction capabilities.
 
 ::: sweagent.agent.agents.RetryAgentConfig
 
 ::: sweagent.agent.agents.DefaultAgentConfig
+
+::: sweagent.agent.agents.ShellAgentConfig

--- a/docs/reference/batch_instances.md
+++ b/docs/reference/batch_instances.md
@@ -1,3 +1,7 @@
+# Batch instances
+
+This page documents the batch instances functionality for running SWE-agent on multiple problems.
+
 ::: sweagent.run.batch_instances
     options:
         members_order: source

--- a/docs/reference/bundle_config.md
+++ b/docs/reference/bundle_config.md
@@ -3,7 +3,7 @@
 !!! note "Tool bundle configuration"
 
     This is the page for configuring a tool bundle, not for setting up the tools that are being used for the agent.
-    For the latter, see [tools configuration](./tools_config.md).
+    For the latter, see [tools configuration](tools_config.md).
 
 ::: sweagent.tools.bundle.BundleConfig
 

--- a/docs/reference/env.md
+++ b/docs/reference/env.md
@@ -1,5 +1,9 @@
 # The environment class
 
+This page documents the `SWEEnv` class, which provides the environment for the agent to interact with.
+To learn about the configuration objects used to specify the behavior of the environment,
+see the [environment configuration reference page](env_config.md).
+
 ::: sweagent.environment.swe_env.SWEEnv
     options:
       allow_inspection: false

--- a/docs/reference/model_config.md
+++ b/docs/reference/model_config.md
@@ -18,6 +18,22 @@ In most cases, you will want to use the `GenericAPIModelConfig` object.
     options:
         heading_level: 3
 
+::: sweagent.agent.models.HumanModelConfig
+    options:
+        heading_level: 3
+
+::: sweagent.agent.models.HumanThoughtModelConfig
+    options:
+        heading_level: 3
+
+::: sweagent.agent.models.ReplayModelConfig
+    options:
+        heading_level: 3
+
+::: sweagent.agent.models.InstantEmptySubmitModelConfig
+    options:
+        heading_level: 3
+
 ## Manual models for testing
 
 The following two models allow you to test your environment by prompting you for actions.

--- a/docs/reference/parsers.md
+++ b/docs/reference/parsers.md
@@ -1,3 +1,7 @@
 # Action parsers
 
+This page documents the action parsing functionality used by SWE-agent to parse and validate agent actions.
+
+The parsing module contains utilities for parsing agent commands and ensuring they conform to the expected format.
+
 ::: sweagent.tools.parsing

--- a/docs/reference/run_batch_config.md
+++ b/docs/reference/run_batch_config.md
@@ -1,1 +1,5 @@
+# Batch run configuration
+
+This page documents the configuration options for running SWE-agent in batch mode on multiple problems.
+
 ::: sweagent.run.run_batch.RunBatchConfig

--- a/docs/reference/run_single_config.md
+++ b/docs/reference/run_single_config.md
@@ -1,3 +1,7 @@
+# Single run configuration
+
+This page documents the configuration options for running SWE-agent on a single problem.
+
 ::: sweagent.run.run_single.RunSingleConfig
 
 ::: sweagent.run.run_single.RunSingleActionConfig

--- a/docs/reference/template_config.md
+++ b/docs/reference/template_config.md
@@ -1,3 +1,7 @@
 # Template configuration
 
+This page documents the template configuration used by SWE-agent to define message templates and formatting.
+
+Templates are used to format various messages that the agent sends and receives, including system prompts, user messages, and tool responses.
+
 ::: sweagent.agent.agents.TemplateConfig

--- a/docs/reference/tools_config.md
+++ b/docs/reference/tools_config.md
@@ -5,7 +5,7 @@ This shows how to configure tools for SWE-agent.
 !!! note "Tool configuration"
 
     This is the page for configuring tools for SWE-agent, not for setting up the tools that are being used for the agent.
-    For the latter, see [tool bundles](./bundle_config.md).
+    For the latter, see [tool bundles](bundle_config.md).
 
 ::: sweagent.tools.tools.ToolConfig
 


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

This PR improves the reference documentation by adding descriptive content and fixing internal links throughout the documentation. The changes enhance the user experience by providing clear descriptions of what each configuration page covers and ensuring proper navigation between related pages.

The following files have been modified:

- **docs/reference/agent_config.md**: Added `ShellAgentConfig` to the list of agent classes and updated the count from two to three main agent classes
- **docs/reference/batch_instances.md**: Added title and description explaining the batch instances functionality
- **docs/reference/bundle_config.md**: Fixed internal link formatting by removing `./` prefix
- **docs/reference/env.md**: Added description of the `SWEEnv` class and cross-reference to environment configuration
- **docs/reference/model_config.md**: Added documentation for additional model config classes (`HumanModelConfig`, `HumanThoughtModelConfig`, `ReplayModelConfig`, `InstantEmptySubmitModelConfig`)
- **docs/reference/parsers.md**: Added description of the action parsing functionality
- **docs/reference/run_batch_config.md**: Added title and description for batch run configuration
- **docs/reference/run_single_config.md**: Added title and description for single run configuration
- **docs/reference/template_config.md**: Added description of template configuration functionality
- **docs/reference/tools_config.md**: Fixed internal link formatting by removing `./` prefix

These improvements make the documentation more accessible and easier to navigate for users looking to understand and configure SWE-agent.