### PR TITLE
support claude thinking blocks

### DIFF
--- a/sweagent/agent/agents.py
+++ b/sweagent/agent/agents.py
@@ -722,6 +722,7 @@ class DefaultAgent(AbstractAgent):
                 "agent": self.name,
                 "tool_calls": step.tool_calls,
                 "message_type": "action",
+                "thinking_blocks":step.thinking_blocks,
             },
         )
 
@@ -1042,6 +1043,7 @@ class DefaultAgent(AbstractAgent):
             step.output = output["message"]
             # todo: Can't I override the parser in __init__?
             step.thought, step.action = self.tools.parse_actions(output)
+            step.thinking_blocks = output.get("thinking_blocks", [])
             if output.get("tool_calls") is not None:
                 step.tool_call_ids = [call["id"] for call in output["tool_calls"]]
                 step.tool_calls = output["tool_calls"]

--- a/sweagent/agent/hooks/abstract.py
+++ b/sweagent/agent/hooks/abstract.py
@@ -116,6 +116,7 @@ class CombinedAgentHook(AbstractAgentHook):
         action: str = "",
         tool_calls: list[dict[str, str]] | None = None,
         tool_call_ids: list[str] | None = None,
+        thinking_blocks: list[dict[str, str]] | None = None
     ):
         for hook in self.hooks:
             hook.on_query_message_added(

--- a/sweagent/agent/models.py
+++ b/sweagent/agent/models.py
@@ -685,6 +685,8 @@ class LiteLLMModel(AbstractModel):
         for message in messages_no_cache_control:
             if "cache_control" in message:
                 del message["cache_control"]
+            if "thinking_blocks" in message:
+                del message["thinking_blocks"]
         input_tokens: int = litellm.utils.token_counter(
             messages=messages_no_cache_control,
             model=self.custom_tokenizer["identifier"] if self.custom_tokenizer is not None else self.config.name,
@@ -732,7 +734,7 @@ class LiteLLMModel(AbstractModel):
             raise
         self.logger.debug(f"Response: {response}")
         try:
-            cost = litellm.cost_calculator.completion_cost(response)
+            cost = litellm.cost_calculator.completion_cost(response,model=self.config.name)
         except Exception as e:
             self.logger.debug(f"Error calculating cost: {e}, setting cost to 0.")
             if self.config.per_instance_cost_limit > 0 or self.config.total_cost_limit > 0:
@@ -759,6 +761,8 @@ class LiteLLMModel(AbstractModel):
             if self.tools.use_function_calling:
                 if response.choices[i].message.tool_calls:  # type: ignore
                     tool_calls = [call.to_dict() for call in response.choices[i].message.tool_calls]  # type: ignore
+                    if hasattr(response.choices[i].message,"thinking_blocks") and response.choices[i].message.thinking_blocks: #type: ignore
+                        output_dict["thinking_blocks"] = response.choices[i].message.thinking_blocks  # type: ignore
                 else:
                     tool_calls = []
                 output_dict["tool_calls"] = tool_calls
@@ -846,6 +850,8 @@ class LiteLLMModel(AbstractModel):
                 }
             elif (tool_calls := history_item.get("tool_calls")) is not None:
                 message = {"role": role, "content": history_item["content"], "tool_calls": tool_calls}
+                if thinking_blocks := history_item.get("thinking_blocks"):
+                    message["thinking_blocks"] = thinking_blocks
             else:
                 message = {"role": role, "content": history_item["content"]}
             if "cache_control" in history_item:

--- a/sweagent/types.py
+++ b/sweagent/types.py
@@ -25,6 +25,8 @@ class StepOutput(BaseModel):
     state: dict[str, str] = {}
     tool_calls: list[dict[str, Any]] | None = None
     tool_call_ids: list[str] | None = None
+    thinking_blocks: list[dict[str, Any]] | None = None
+
     """State of the environment at the end of the step"""
     extra_info: dict[str, Any] = {}
 
@@ -67,6 +69,8 @@ class HistoryItem(_HistoryItem, total=False):
     tool_call_ids: list[str] | None
     tags: list[str]
     cache_control: dict[str, Any] | None
+    thinking_blocks: list[dict[str, Any]] | None 
+
     """HistoryProcessors can add these tags to enable special processing"""
 
 


### PR DESCRIPTION

<!--
Thanks for contributing a pull request!
-->

#### Reference Issues/PRs
<!--
sweagent failed when running with claude-sonet-4 on vertex ai due to:
- thinking blocks required on subsequent calls [extended thinking](https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking#extended-thinking-with-tool-use)
- token counter failed because of thinking_block os not one of the expected values 
- model cost calc in litellm failed because lack of llm provider
-->

#### What does this implement/fix? Explain your changes.
<!--
Added thinking_blocks to stepOutput, HistoryItems and hooks so it can be sent back in consequent calls
Added model name explicit passing for cost calc which failed without it for vertex_ai/claude-sonnet-4
Removed thinking blocks from token_counter messages so it does not fail, same as cache messages

-->
