### PR TITLE
Add an option for the submit tool to submit a file

### DIFF
--- a/config/test/submit_file_test.yaml
+++ b/config/test/submit_file_test.yaml
@@ -1,0 +1,152 @@
+# Formerly called: anthropic_filemap.yaml
+# This template is heavily inspired by anthropic's computer use demo, but you can use
+# it with any LM.
+agent:
+  templates:
+    system_template: |-
+      SETTING: You are an autonomous programmer, and you're working directly in the command line with a special interface.
+
+      The special interface consists of a file editor that shows you {{WINDOW}} lines of a file at a time.
+      In addition to typical bash commands, you can also use specific commands to help you navigate and edit files.
+      To call a command, you need to invoke it with a function call/tool call.
+
+      Please note that THE EDIT COMMAND REQUIRES PROPER INDENTATION.
+
+      For example, if you are looking at this file:
+
+      def fct():
+          print("Hello world")
+
+      and you want to edit the file to read:
+
+      def fct():
+          print("Hello")
+          print("world")
+
+      you search string should be `Hello world` and your replace string should be `"Hello"\n    print("world")`
+      (note the extra spaces before the print statement!).
+
+      You could also get the same result by search for `    print("Hello world")` and replace with `    print("Hello")\n    print("world")`.
+
+      RESPONSE FORMAT:
+      Your shell prompt is formatted as follows:
+      (Open file: <path>)
+      (Current directory: <cwd>)
+      bash-$
+
+      First, you should _always_ include a general thought about what you're going to do next.
+      Then, for every response, you must include exactly _ONE_ tool call/function call.
+
+      Remember, you should always include a _SINGLE_ tool call/function call and then wait for a response from the shell before continuing with more discussion and commands. Everything you include in the DISCUSSION section will be saved for future reference.
+      If you'd like to issue two commands at once, PLEASE DO NOT DO THAT! Please instead first submit just the first tool call, and then after receiving a response you'll be able to issue the second .
+    instance_template: |-
+      We're currently solving the following issue within our repository. Here's the problem statement:
+      
+      PROBLEM_STATEMENT:
+      ###
+      {{problem_statement}}
+      ###
+
+      Can you help me implement the necessary changes to the repository so that the requirements specified in the <PROBLEM_STATEMENT>?
+
+      INSTRUCTIONS:
+      Now, you're going to solve this issue on your own. Your terminal session has started and you're in the repository's root directory. You can use any bash commands or the special interface to help you. Edit all the files you need to and run any checks or tests that you want.
+      Remember, YOU SHOULD ALWAYS INCLUDE EXACTLY ONE TOOL CALL/FUNCTION CALL PER RESPONSE.
+      When you're satisfied with all of the changes you've made, you can submit your changes to the code base by simply running the submit command.
+      Note however that you cannot use any interactive session commands (e.g. python, vim) in this environment, but you can write scripts and run them. E.g. you can write a python script and then run it with the python command.
+
+      NOTE ABOUT THE EDIT COMMAND: Indentation really matters! When editing a file, make sure to insert appropriate indentation before each line!
+
+      GENERAL IMPORTANT TIPS:
+
+      1. If you run a command and it doesn't work, try running a different command. A command that did not work once will not work the second time unless you modify it!
+
+      2. If you open a file and need to get to an area around a specific line that is not in the first 100 lines, say line 583, don't just use the scroll_down command multiple times. Instead, use the goto 583 command. It's much quicker.
+
+      3. If the bug reproduction script requires inputting/reading a specific file, such as buggy-input.png, and you'd like to understand how to input that file, conduct a search in the existing repo code, to see whether someone else has already done that. Do this by running the command: find_file "buggy-input.png" If that doesn't work, use the linux 'find' command.
+
+      4. Always make sure to look at the currently open file and the current working directory (which appears right after the currently open file). The currently open file might be in a different directory than the working directory! Note that some commands, such as 'create', open files, so they might change the current open file.
+
+      5. When editing files, it is easy to accidentally to write code with incorrect indentation or make other mistakes. Always check the code after you issue an edit to make sure that it reflects what you wanted to accomplish. If it didn't, issue another command to fix it.
+
+      6. When editing files, first explain the code you want to edit and why it is causing the problem. Then explain the edit you want to make and how it fixes the problem. Explain how the edit does not break existing functionality.
+
+      7. Do not try to install any packages with `pip`, `conda`, or any other way. This will usually not work. If the environment is not set up correctly, try to fix the issue without executing python code or running any tests that require the package installed.
+
+      STRATEGY:
+
+      1. Always start by trying to replicate the bug that the issues discusses.
+        If the issue includes code for reproducing the bug, we recommend that you re-implement that in your environment, and run it to make sure you can reproduce the bug.
+        Then start trying to fix it.
+
+        If the bug reproduction script does not print anything when it successfully runs, we recommend adding a print("Script completed successfully, no errors.") command at the end of the file,
+        so that you can be sure that the script indeed ran fine all the way through.
+
+      2. Locate relevant code using the find and search commands. `open` the file you want to edit.
+
+      3. Use the `edit` command to perform edits.
+
+      4. When you think you've fixed the bug, re-run the bug reproduction script to make sure that the bug has indeed been fixed.
+
+      5. Create additional tests to verify the fix in a style similar to the existing reproduction script. In particular, make sure to test edge cases.
+         If you find any issues, go back to the file you edited and perform further edits.
+
+      (Open file: {{open_file}})
+      (Current directory: {{working_dir}})
+      bash-$
+    next_step_template: |-
+      {{observation}}
+      (Open file: {{open_file}})
+      (Current directory: {{working_dir}})
+      bash-$
+    next_step_no_output_template: |-
+      Your command ran successfully and did not produce any output.
+      (Open file: {{open_file}})
+      (Current directory: {{working_dir}})
+      bash-$
+    demonstrations:
+      - trajectories/demonstrations/replay__marshmallow-code__marshmallow-1867__function_calling_replace__install-1/marshmallow-code__marshmallow-1867.traj
+    put_demos_in_history: true
+  tools:
+    execution_timeout: 180
+    env_variables:
+      WINDOW: 100
+      OVERLAP: 2
+      PAGER: cat
+      MANPAGER: cat
+      LESS: -R
+      PIP_PROGRESS_BAR: 'off'
+      TQDM_DISABLE: '1'
+      GIT_PAGER: cat
+    bundles:
+      - path: tools/registry
+      - path: tools/windowed
+      - path: tools/search
+      - path: tools/windowed_edit_replace
+      - path: tools/submit
+    enable_bash_tool: true
+    parse_function:
+      type: function_calling
+  history_processors:
+    - type: last_n_observations
+      n: 5
+  model:
+    name: azure/gpt-4o
+env:
+  repo:
+    github_url: https://github.com/bminor/binutils-gdb.git
+    type: github
+problem_statement:
+  type: text
+  text: |
+    Give me detailed description of `apply_bit_offset_to_field` function.
+    Save it in `/model/function_description.json` and submit it with `submit /model/function_description.json`.
+    Provide me the output in a json format with the following keys:
+    - description: A detailed description of the function.
+    - parameters:
+      - name: The name of the parameter.
+        type: The type of the parameter.
+        description: A detailed description of the parameter.
+    - returns: A detailed description of the return value.
+    - raises: A list of exceptions that the function can raise, along with a detailed description
+      of each exception. None if there are no exceptions.

--- a/sweagent/agent/agents.py
+++ b/sweagent/agent/agents.py
@@ -901,6 +901,35 @@ class DefaultAgent(AbstractAgent):
                 step.exit_status = f"submitted ({step.exit_status})"
             step.done = True
             self.logger.info(f"Found submission: {submission}")
+
+        is_file_submission = self.tools.check_for_file_submission_cmd(observation or step.observation)
+        if is_file_submission:
+            assert self._env is not None
+            try:
+                file_name = self._env.read_file("/root/submission_file_name.txt", encoding="utf-8").strip()
+                file_content = self._env.read_file("/root/submission_file.txt", encoding="utf-8")
+            except FileNotFoundError:
+                self.logger.warning("File submission file not found, no file submission was made")
+                return step
+            except Exception as e:
+                self.logger.exception("Failed to read file submission files, got %s", e)
+                return step
+            if file_content.strip() != "":
+                step.submission = {
+                    "file_name": file_name,
+                    "file_content": file_content,
+                }
+            else:
+                step.submission = None
+            step.observation = f"File submission: {file_name}"
+            if not step.exit_status:
+                step.exit_status = "submitted"
+            elif step.submission:
+                step.exit_status = f"submitted ({step.exit_status})"
+            step.done = True
+            self.logger.info(f"Found file submission: {file_name}")
+            self.logger.info(f"File content: {file_content[:100]}... (truncated)")
+
         return step
 
     def _get_edited_files_with_context(self, patch: str) -> dict[str, str]:

--- a/sweagent/agent/agents.py
+++ b/sweagent/agent/agents.py
@@ -908,8 +908,8 @@ class DefaultAgent(AbstractAgent):
             try:
                 file_name = self._env.read_file("/root/submission_file_name.txt", encoding="utf-8").strip()
                 file_content = self._env.read_file("/root/submission_file.txt", encoding="utf-8")
-            except FileNotFoundError:
-                self.logger.warning("File submission file not found, no file submission was made")
+            except FileNotFoundError as e:
+                self.logger.warning(f"File submission file not found, no file submission was made. Error: {e}")
                 return step
             except Exception as e:
                 self.logger.exception("Failed to read file submission files, got %s", e)

--- a/sweagent/run/hooks/apply_patch.py
+++ b/sweagent/run/hooks/apply_patch.py
@@ -30,11 +30,13 @@ class SaveApplyPatchHook(RunHook):
         self._problem_statement = problem_statement
 
     def on_instance_completed(self, *, result: AgentRunResult):
+        instance_id = self._problem_statement.id
+
         if self._is_file_submission(result.info):
             self.logger.info("Received file submission.")
-            self._save_file_submission(result.info)
+            self._save_file_submission(instance_id, result.info)
             return
-        instance_id = self._problem_statement.id
+
         patch_path = self._save_patch(instance_id, result.info)
         if patch_path:
             if not self._apply_patch_locally:
@@ -81,7 +83,7 @@ class SaveApplyPatchHook(RunHook):
             return True
         return False
 
-    def _save_file_submission(self, info):
+    def _save_file_submission(self, instance_id: str, info):
         """Save the file submission to the output directory."""
         file_info = info["submission"]
         file_name = file_info.get("file_name")
@@ -89,7 +91,7 @@ class SaveApplyPatchHook(RunHook):
             self.logger.warning("No file name found in submission info.")
             return
 
-        output_file_path = self._output_dir / Path(file_name).name
+        output_file_path = self._output_dir / instance_id / Path(file_name).name
         output_file_path.parent.mkdir(parents=True, exist_ok=True)
         if output_file_path.exists():
             self.logger.warning(f"File {output_file_path} already exists. Overwriting.")

--- a/sweagent/tools/tools.py
+++ b/sweagent/tools/tools.py
@@ -375,6 +375,12 @@ class ToolHandler:
             return True
         return False
 
+    def check_for_file_submission_cmd(self, output: str) -> bool:
+        """Function for checking file submission request."""
+        if r"<<SWE_AGENT_FILE_SUBMISSION>>" in output:
+            return True
+        return False
+
     def parse_actions(self, output: dict) -> tuple[str, str]:
         """Parse the model output into a thought and action."""
         return self.config.parse_function(output, self.config.commands)

--- a/sweagent/types.py
+++ b/sweagent/types.py
@@ -79,7 +79,7 @@ class AgentInfo(TypedDict, total=False):
     # same as `APIStats` from models.py
     model_stats: dict[str, float]
     exit_status: str | None
-    submission: str | None
+    submission: str | dict[str, Any] | None
     # same as `ReviewerResult`
     review: dict[str, Any]
     edited_files30: str

--- a/tools/submit/bin/submit
+++ b/tools/submit/bin/submit
@@ -1,5 +1,5 @@
 main() {
-    # If first argument is provided, just print it between the submission markers
+    # If first argument is provided, just print it between the file submission markers
     if [ $# -gt 0 ]; then
         echo "<<SWE_AGENT_FILE_SUBMISSION>>"
         echo "<<TITLE>>"

--- a/tools/submit/bin/submit
+++ b/tools/submit/bin/submit
@@ -1,4 +1,18 @@
 main() {
+    # If first argument is provided, just print it between the submission markers
+    if [ $# -gt 0 ]; then
+        echo "<<SWE_AGENT_FILE_SUBMISSION>>"
+        echo "<<TITLE>>"
+        echo "$1"
+        echo "<<TITLE>>"
+        cat "$1"
+        echo "<<SWE_AGENT_FILE_SUBMISSION>>"
+
+        echo $1 > /root/submission_file_name.txt
+        mv "$1" /root/submission_file.txt
+        return 0
+    fi
+
     cd $ROOT
 
     # Check if the patch file exists and is non-empty

--- a/tools/submit/config.yaml
+++ b/tools/submit/config.yaml
@@ -1,5 +1,10 @@
 tools:
   submit:
-    signature: "submit"
+    signature: "submit [<target_file>]"
     docstring: "submits the current file"
-    arguments: []
+    arguments:
+      - name: target_file
+        type: string
+        description: "the file to submit (if not provided, submits the diff)"
+        required: false
+


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!
-->

#### Reference Issues/PRs
<!--
Example: "Fixes #1234", "See also #3456"
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### What does this implement/fix? Explain your changes.
As of now the submission tool generates a patch from the `git diff`. Other than that, if the user wants to get something else from the repo, they can indirectly do it by creating it as a new file in the repo and make it part of the patch.

Instead, this change enables submit tool to handle a file argument. If provided, that file will be simply submitted back to the orchestrator without creating a patch.

<!--
Please include a brief explanation of how your solution
fixes the tagged issue(s), along with what files / entities have
been modified for this fix.
-->
