### PR TITLE
Add `--range` option for `str_replace` command of `edit_anthropic` tool

### DIFF
--- a/tools/edit_anthropic/bin/str_replace_editor
+++ b/tools/edit_anthropic/bin/str_replace_editor
@@ -365,7 +365,7 @@ class EditTool:
         command: Command,
         path: str,
         file_text: Optional[str] = None,
-        view_range: Optional[List[int]] = None,
+        range: Optional[List[int]] = None,
         old_str: Optional[str] = None,
         new_str: Optional[str] = None,
         insert_line: Optional[int] = None,
@@ -374,7 +374,7 @@ class EditTool:
         _path = Path(path)
         self.validate_path(command, _path)
         if command == "view":
-            return self.view(_path, view_range)
+            return self.view(_path, range)
         elif command == "create":
             if file_text is None:
                 print("Parameter `file_text` is required for command: create")
@@ -385,7 +385,7 @@ class EditTool:
             if old_str is None:
                 print("Parameter `old_str` is required for command: str_replace")
                 sys.exit(2)
-            return self.str_replace(_path, old_str, new_str)
+            return self.str_replace(_path, old_str, new_str, range)
         elif command == "insert":
             if insert_line is None:
                 print("Parameter `insert_line` is required for command: insert")
@@ -400,6 +400,39 @@ class EditTool:
             f'Unrecognized command {command}. The allowed commands for the {self.name} tool are: "view", "create", "str_replace", "insert", "undo_edit"'
         )
         sys.exit(5)
+
+    def _get_content_in_range(self, file_content: str, file_suffix: str, range: List[int]) -> str:
+        if len(range) != 2 or not all(isinstance(i, int) for i in range):
+            print("Invalid `range`. It should be a list of two integers.")
+            sys.exit(11)
+        file_lines = file_content.split("\n")
+        n_lines_file = len(file_lines)
+        init_line, final_line = range
+        if init_line < 1 or init_line > n_lines_file:
+            print(
+                f"Invalid `range`: {range}. Its first element `{init_line}` should be within the range of lines of the file: {[1, n_lines_file]}"
+            )
+            sys.exit(12)
+        if final_line > n_lines_file:
+            print(
+                f"Invalid `range`: {range}. Its second element `{final_line}` should be smaller than the number of lines in the file: `{n_lines_file}`"
+            )
+            sys.exit(13)
+        if final_line != -1 and final_line < init_line:
+            print(
+                f"Invalid `range`: {range}. Its second element `{final_line}` should be larger or equal than its first `{init_line}`"
+            )
+            sys.exit(14)
+
+        if final_line == -1:
+            final_line = n_lines_file
+
+        # Expand the viewport to include the whole function or class
+        init_line, final_line = WindowExpander(suffix=file_suffix).expand_window(
+            file_lines, init_line, final_line, max_added_lines=MAX_WINDOW_EXPANSION_VIEW
+        )
+
+        return "\n".join(file_lines[init_line - 1 : final_line]), init_line, final_line
 
     def validate_path(self, command: str, path: Path):
         """
@@ -456,37 +489,7 @@ class EditTool:
 
         file_content = self.read_file(path)
         if view_range:
-            if len(view_range) != 2 or not all(isinstance(i, int) for i in view_range):
-                print("Invalid `view_range`. It should be a list of two integers.")
-                sys.exit(11)
-            file_lines = file_content.split("\n")
-            n_lines_file = len(file_lines)
-            init_line, final_line = view_range
-            if init_line < 1 or init_line > n_lines_file:
-                print(
-                    f"Invalid `view_range`: {view_range}. Its first element `{init_line}` should be within the range of lines of the file: {[1, n_lines_file]}"
-                )
-                sys.exit(12)
-            if final_line > n_lines_file:
-                print(
-                    f"Invalid `view_range`: {view_range}. Its second element `{final_line}` should be smaller than the number of lines in the file: `{n_lines_file}`"
-                )
-                sys.exit(13)
-            if final_line != -1 and final_line < init_line:
-                print(
-                    f"Invalid `view_range`: {view_range}. Its second element `{final_line}` should be larger or equal than its first `{init_line}`"
-                )
-                sys.exit(14)
-
-            if final_line == -1:
-                final_line = n_lines_file
-
-            # Expand the viewport to include the whole function or class
-            init_line, final_line = WindowExpander(suffix=path.suffix).expand_window(
-                file_lines, init_line, final_line, max_added_lines=MAX_WINDOW_EXPANSION_VIEW
-            )
-
-            file_content = "\n".join(file_lines[init_line - 1 : final_line])
+            file_content, init_line, _ = self._get_content_in_range(file_content, path.suffix, view_range)
         else:
             if path.suffix == ".py" and len(file_content) > MAX_RESPONSE_LEN and USE_FILEMAP:
                 try:
@@ -511,12 +514,17 @@ class EditTool:
         # init_line is 1-based
         print(self._make_output(file_content, str(path), init_line=init_line))
 
-    def str_replace(self, path: Path, old_str: str, new_str: Optional[str]):
+    def str_replace(self, path: Path, old_str: str, new_str: Optional[str], range: Optional[List[int]] = None):
         """Implement the str_replace command, which replaces old_str with new_str in the file content"""
         # Read the file content
-        file_content = self.read_file(path).expandtabs()
+        full_file_content = self.read_file(path).expandtabs()
         old_str = old_str.expandtabs()
         new_str = new_str.expandtabs() if new_str is not None else ""
+
+        if range:
+            file_content, init_lines, final_lines = self._get_content_in_range(full_file_content, path.suffix, range)
+        else:
+            file_content = full_file_content
 
         # Check if old_str is unique in the file
         occurrences = file_content.count(old_str)
@@ -527,7 +535,7 @@ class EditTool:
             file_content_lines = file_content.split("\n")
             lines = [idx + 1 for idx, line in enumerate(file_content_lines) if old_str in line]
             print(
-                f"No replacement was performed. Multiple occurrences of old_str `{old_str}` in lines {lines}. Please ensure it is unique"
+                f"No replacement was performed. Multiple occurrences of old_str `{old_str}` in lines {lines}. Please ensure it is unique or use `--range` option to restrict the replacement to a specific range."
             )
             sys.exit(16)
 
@@ -543,7 +551,23 @@ class EditTool:
                 print(f"Warning: Failed to run pre-edit linter on {path}: {e}")
 
         # Replace old_str with new_str
-        new_file_content = file_content.replace(old_str, new_str)
+        if not range:
+            # If no range is provided, we replace in the whole file
+            new_file_content = file_content.replace(old_str, new_str)
+        else:
+            # If range is provided, we only replace in the specified range
+            updated_content = file_content.replace(old_str, new_str)
+
+            full_file_lines = full_file_content.split("\n")
+            # We want to update the portion between init_lines inclusive and final_lines exclusive.
+            # init_lines and final_lines are 1-based, so we need to adjust them for slicing
+            # So, init_lines - 1 is the last line before the range starts and right index in python slicing is exclusive.
+            # final_lines is the first line after the range ends and left index is inclusive.
+            new_file_content = (                                        # --- Below range is 0-based and inclusive ---
+                "\n".join(full_file_lines[: init_lines - 1]) + "\n" +   #     0 to init_lines - 2
+                updated_content + "\n" +                                #     init_lines - 1 to final_lines
+                "\n".join(full_file_lines[final_lines:])                #     final_lines to end
+            )
 
         # Write the new content to the file
         self.write_file(path, new_file_content)
@@ -578,6 +602,13 @@ class EditTool:
         replacement_line = file_content.split(old_str)[0].count("\n")
         start_line = max(1, replacement_line - SNIPPET_LINES)
         end_line = min(replacement_line + SNIPPET_LINES + new_str.count("\n"), len(new_file_content.splitlines()))
+
+        # Offset the start and end lines if range is provided
+        if range:
+            # expand_window expects 1-based line numbers and range is 1-based
+            start_line += init_lines - 1 # start_line inclusive
+            end_line += init_lines
+
         start_line, end_line = WindowExpander(suffix=path.suffix).expand_window(
             new_file_content.split("\n"), start_line, end_line, max_added_lines=MAX_WINDOW_EXPANSION_EDIT_CONFIRM
         )
@@ -689,7 +720,7 @@ def main():
     parser.add_argument("command", type=str)
     parser.add_argument("path", type=str)
     parser.add_argument("--file_text", type=str)
-    parser.add_argument("--view_range", type=int, nargs=2)
+    parser.add_argument("--range", type=int, nargs=2)
     parser.add_argument("--old_str", type=str)
     parser.add_argument("--new_str", type=str)
     parser.add_argument("--insert_line", type=int)
@@ -699,7 +730,7 @@ def main():
         command=args.command,
         path=args.path,
         file_text=args.file_text,
-        view_range=args.view_range,
+        range=args.range,
         old_str=args.old_str,
         new_str=args.new_str,
         insert_line=args.insert_line,

--- a/tools/edit_anthropic/config.yaml
+++ b/tools/edit_anthropic/config.yaml
@@ -1,7 +1,7 @@
 tools:
   str_replace_editor:
     signature: |
-      str_replace_editor <command> <path> [<file_text>] [<view_range>] [<old_str>] [<new_str>] [<insert_line>]
+      str_replace_editor <command> <path> [<file_text>] [<range>] [<old_str>] [<new_str>] [<insert_line>]
     # This docstrings was taken from openhands:
     # https://github.com/All-Hands-AI/OpenHands/blob/main/openhands/agenthub/codeact_agent/function_calling.py
     docstring: >
@@ -13,8 +13,9 @@ tools:
       * The `undo_edit` command will revert the last edit made to the file at `path`
 
       Notes for using the `str_replace` command:
-      * The `old_str` parameter should match EXACTLY one or more consecutive lines from the original file. Be mindful of whitespaces!
-      * If the `old_str` parameter is not unique in the file, the replacement will not be performed. Make sure to include enough context in `old_str` to make it unique
+      * The `old_str` parameter should match EXACTLY one or more consecutive lines from the original file or in the lines specified by `range`. Be mindful of whitespaces!
+      * The `range` parameter should be used to limit the search for the `old_str` to a specific range of lines in the file. If not provided, the entire file will be searched.
+      * If the `old_str` parameter is not unique, the replacement will not be performed. Make sure to include enough context in `old_str` to make it unique or use the `range` parameter to limit the search to a specific range of lines.
       * The `new_str` parameter should contain the edited lines that should replace the `old_str`
     arguments:
       - name: command
@@ -46,11 +47,11 @@ tools:
         description: "Required parameter of `insert` command. The `new_str` will be inserted AFTER the line `insert_line` of `path`."
         required: false
         argument_format: "--insert_line {{value}}"
-      - name: view_range
+      - name: range
         type: array
         items:
           type: integer
-        description: "Optional parameter of `view` command when `path` points to a file. If none is given, the full file is shown. If provided, the file will be shown in the indicated line number range, e.g. [11, 12] will show lines 11 and 12. Indexing at 1 to start. Setting `[start_line, -1]` shows all lines from `start_line` to the end of the file."
+        description: "Optional parameter of `view` and `str_replace` commands when `path` points to a file. If none is given, the full file is used for consideration. If provided, the file will be shown or searched in the indicated line number range, e.g. [11, 12] will show lines 11 and 12 for `view` command whereas it will search for `old_str` among lines 11 and 12 for `str_replace` command. Indexing at 1 to start. Setting `[start_line, -1]` is wildcard to consider `start_line` to the end of the file."
         required: false
-        argument_format: "--view_range {{value|join(' ')}}"
+        argument_format: "--range {{value|join(' ')}}"
 state_command: "_state_anthropic"


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!
-->

#### Reference Issues/PRs
<!--
Example: "Fixes #1234", "See also #3456"
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### What does this implement/fix? Explain your changes.
<!--
Please include a brief explanation of how your solution
fixes the tagged issue(s), along with what files / entities have
been modified for this fix.
-->
Usually, models view only a portion of the source file using `--view_range` option and tries to edit the file. When the file is bigger, the string-matching may not be unique and it becomes responsibility of the model to find a unique combination combining multiple lines before and after. This new option provides a way for the model to restrict the search and replacement to the provided range.

As `--range` option is common for both view and edit commands now, it's renamed from `--view_range` to `--range`.


#### Reference Log while testing with Linux Kernel code
```
2025-07-25 05:13:56,570 - INFO - swea-agent - ========================= STEP 10 =========================
2025-07-25 05:13:56,572 - DEBUG - swea-lm - n_cache_control: 0
2025-07-25 05:13:58,328 - DEBUG - swea-lm - Response: ModelResponse(id='chatcmpl-Bx52i7SwXvkvjotVvUN2x1TabM2mz', created=1753420436, model='gpt-4.1-2025-04-14', object='chat.completion', system_fingerprint='fp_07e970ab25', choices=[Choices(finish_reason='tool_calls', index=0, message=Message(content="I see the line to change:\n\n< &tegra_car TEGRA114_CLK_PLL_D2_OUT0 >;\n\nshould become:\n\n< &tegra_car TEGRA114_CLK_PLL_D_OUT0 >;\n\nI'll make this change now, preserving indentation.", role='assistant', tool_calls=[ChatCompletionMessageToolCall(function=Function(arguments='{"command":"str_replace","path":"/linux_swe_repo/code_base/arch/arm/boot/dts/tegra114.dtsi","old_str":"                             <&tegra_car TEGRA114_CLK_PLL_D2_OUT0>;","new_str":"                             <&tegra_car TEGRA114_CLK_PLL_D_OUT0>;" }', name='str_replace_editor'), id='call_tknQvTCPpuAyF7dn2EY1R1ZG', type='function')], function_call=None, provider_specific_fields={'refusal': None}, annotations=[]), provider_specific_fields={'content_filter_results': {'hate': {'filtered': False, 'severity': 'safe'}, 'protected_material_code': {'detected': False, 'filtered': False}, 'protected_material_text': {'detected': False, 'filtered': False}, 'self_harm': {'filtered': False, 'severity': 'safe'}, 'sexual': {'filtered': False, 'severity': 'safe'}, 'violence': {'filtered': False, 'severity': 'safe'}}})], usage=Usage(completion_tokens=145, prompt_tokens=12194, total_tokens=12339, completion_tokens_details=CompletionTokensDetailsWrapper(accepted_prediction_tokens=0, audio_tokens=0, reasoning_tokens=0, rejected_prediction_tokens=0, text_tokens=None), prompt_tokens_details=PromptTokensDetailsWrapper(audio_tokens=0, cached_tokens=11520, text_tokens=None, image_tokens=None)), service_tier=None, prompt_filter_results=[{'prompt_index': 0, 'content_filter_results': {'hate': {'filtered': False, 'severity': 'safe'}, 'jailbreak': {'filtered': False, 'detected': False}, 'self_harm': {'filtered': False, 'severity': 'safe'}, 'sexual': {'filtered': False, 'severity': 'safe'}, 'violence': {'filtered': False, 'severity': 'safe'}}}])
2025-07-25 05:13:58,333 - DEBUG - swea-lm - input_tokens=11,570, output_tokens=61, instance_cost=0.12, cost=0.01
2025-07-25 05:13:58,334 - DEBUG - swea-lm - total_tokens_sent=92,206, total_tokens_received=475, total_cost=0.12, total_api_calls=10
2025-07-25 05:13:58,336 - INFO - swea-agent - 💭 THOUGHT
I see the line to change:

< &tegra_car TEGRA114_CLK_PLL_D2_OUT0 >;

should become:

< &tegra_car TEGRA114_CLK_PLL_D_OUT0 >;

I'll make this change now, preserving indentation.

🎬 ACTION
str_replace_editor str_replace /linux_swe_repo/code_base/arch/arm/boot/dts/tegra114.dtsi   --old_str '                             <&tegra_car TEGRA114_CLK_PLL_D2_OUT0>;' --new_str '                             <&tegra_car TEGRA114_CLK_PLL_D_OUT0>;'
2025-07-25 05:13:58,338 - TRACE - swea-env - Input:
str_replace_editor str_replace /linux_swe_repo/code_base/arch/arm/boot/dts/tegra114.dtsi   --old_str '                             <&tegra_car TEGRA114_CLK_PLL_D2_OUT0>;' --new_str '                             <&tegra_car TEGRA114_CLK_PLL_D_OUT0>;'
2025-07-25 05:13:58,487 - TRACE - swea-env - Output:
No replacement was performed. Multiple occurrences of old_str `                             <&tegra_car TEGRA114_CLK_PLL_D2_OUT0>;` in lines [98, 126]. Please ensure it is unique or use `--range` option to restrict the replacement to a specific range.

2025-07-25 05:13:58,487 - TRACE - swea-env - Input:
_state_anthropic
2025-07-25 05:13:58,618 - TRACE - swea-env - Output:

2025-07-25 05:13:58,620 - DEBUG - swea-tools - Retrieved state from environment: {'working_dir': '/linux_swe_repo/code_base'}
2025-07-25 05:13:58,622 - INFO - swea-agent - 🤖 MODEL INPUT
No replacement was performed. Multiple occurrences of old_str `                             <&tegra_car TEGRA114_CLK_PLL_D2_OUT0>;` in lines [98, 126]. Please ensure it is unique or use `--range` option to restrict the replacement to a specific range.

(Open file: )
(Current directory: /linux_swe_repo/code_base)
bash-$
2025-07-25 05:13:58,631 - INFO - swea-agent - ========================= STEP 11 =========================
2025-07-25 05:13:58,632 - DEBUG - swea-lm - n_cache_control: 0
2025-07-25 05:14:00,304 - DEBUG - swea-lm - Response: ModelResponse(id='chatcmpl-Bx52kpzrrxDUIN75MDdJc6lIXglIw', created=1753420438, model='gpt-4.1-2025-04-14', object='chat.completion', system_fingerprint='fp_07e970ab25', choices=[Choices(finish_reason='tool_calls', index=0, message=Message(content="There are two occurrences of the line in the file, but the patch only changes the one in the DSI node (around line 126). To avoid affecting the HDMI node (around line 98), I'll restrict the replacement to lines 120-135, which covers the DSI node only.", role='assistant', tool_calls=[ChatCompletionMessageToolCall(function=Function(arguments='{"command":"str_replace","path":"/linux_swe_repo/code_base/arch/arm/boot/dts/tegra114.dtsi","old_str":"                             <&tegra_car TEGRA114_CLK_PLL_D2_OUT0>;","new_str":"                             <&tegra_car TEGRA114_CLK_PLL_D_OUT0>;","range":[120,135]}', name='str_replace_editor'), id='call_aI1njYASIau5ieOXWHU0EITR', type='function')], function_call=None, provider_specific_fields={'refusal': None}, annotations=[]), provider_specific_fields={'content_filter_results': {'hate': {'filtered': False, 'severity': 'safe'}, 'protected_material_code': {'detected': False, 'filtered': False}, 'protected_material_text': {'detected': False, 'filtered': False}, 'self_harm': {'filtered': False, 'severity': 'safe'}, 'sexual': {'filtered': False, 'severity': 'safe'}, 'violence': {'filtered': False, 'severity': 'safe'}}})], usage=Usage(completion_tokens=150, prompt_tokens=12423, total_tokens=12573, completion_tokens_details=CompletionTokensDetailsWrapper(accepted_prediction_tokens=0, audio_tokens=0, reasoning_tokens=0, rejected_prediction_tokens=0, text_tokens=None), prompt_tokens_details=PromptTokensDetailsWrapper(audio_tokens=0, cached_tokens=12288, text_tokens=None, image_tokens=None)), service_tier=None, prompt_filter_results=[{'prompt_index': 0, 'content_filter_results': {'hate': {'filtered': False, 'severity': 'safe'}, 'jailbreak': {'filtered': False, 'detected': False}, 'self_harm': {'filtered': False, 'severity': 'safe'}, 'sexual': {'filtered': False, 'severity': 'safe'}, 'violence': {'filtered': False, 'severity': 'safe'}}}])
2025-07-25 05:14:00,309 - DEBUG - swea-lm - input_tokens=11,803, output_tokens=61, instance_cost=0.12, cost=0.01
2025-07-25 05:14:00,310 - DEBUG - swea-lm - total_tokens_sent=104,009, total_tokens_received=536, total_cost=0.12, total_api_calls=11
2025-07-25 05:14:00,313 - INFO - swea-agent - 💭 THOUGHT
There are two occurrences of the line in the file, but the patch only changes the one in the DSI node (around line 126). To avoid affecting the HDMI node (around line 98), I'll restrict the replacement to lines 120-135, which covers the DSI node only.

🎬 ACTION
str_replace_editor str_replace /linux_swe_repo/code_base/arch/arm/boot/dts/tegra114.dtsi  --range 120 135 --old_str '                             <&tegra_car TEGRA114_CLK_PLL_D2_OUT0>;' --new_str '                             <&tegra_car TEGRA114_CLK_PLL_D_OUT0>;'
2025-07-25 05:14:00,314 - TRACE - swea-env - Input:
str_replace_editor str_replace /linux_swe_repo/code_base/arch/arm/boot/dts/tegra114.dtsi  --range 120 135 --old_str '                             <&tegra_car TEGRA114_CLK_PLL_D2_OUT0>;' --new_str '                             <&tegra_car TEGRA114_CLK_PLL_D_OUT0>;'
2025-07-25 05:14:00,472 - TRACE - swea-env - Output:
The file /linux_swe_repo/code_base/arch/arm/boot/dts/tegra114.dtsi has been edited. Here's the result of running `cat -n` on a snippet of /linux_swe_repo/code_base/arch/arm/boot/dts/tegra114.dtsi:
   121	                dsi@54400000 {
   122	                        compatible = "nvidia,tegra114-dsi";
   123	                        reg = <0x54400000 0x00040000>;
   124	                        clocks = <&tegra_car TEGRA114_CLK_DSIB>,
   125	                                 <&tegra_car TEGRA114_CLK_DSIBLP>,
   126	                                 <&tegra_car TEGRA114_CLK_PLL_D_OUT0>;
   127	                        clock-names = "dsi", "lp", "parent";
   128	                        resets = <&tegra_car 82>;
   129	                        reset-names = "dsi";
   130	                        nvidia,mipi-calibrate = <&mipi 0x180>; /* DSIC & DSID pads */
Review the changes and make sure they are as expected. Edit the file again if necessary.

2025-07-25 05:14:00,472 - TRACE - swea-env - Input:
_state_anthropic
2025-07-25 05:14:00,603 - TRACE - swea-env - Output:

2025-07-25 05:14:00,606 - DEBUG - swea-tools - Retrieved state from environment: {'working_dir': '/linux_swe_repo/code_base'}
2025-07-25 05:14:00,608 - INFO - swea-agent - 🤖 MODEL INPUT
The file /linux_swe_repo/code_base/arch/arm/boot/dts/tegra114.dtsi has been edited. Here's the result of running `cat -n` on a snippet of /linux_swe_repo/code_base/arch/arm/boot/dts/tegra114.dtsi:
   121	                dsi@54400000 {
   122	                        compatible = "nvidia,tegra114-dsi";
   123	                        reg = <0x54400000 0x00040000>;
   124	                        clocks = <&tegra_car TEGRA114_CLK_DSIB>,
   125	                                 <&tegra_car TEGRA114_CLK_DSIBLP>,
   126	                                 <&tegra_car TEGRA114_CLK_PLL_D_OUT0>;
   127	                        clock-names = "dsi", "lp", "parent";
   128	                        resets = <&tegra_car 82>;
   129	                        reset-names = "dsi";
   130	                        nvidia,mipi-calibrate = <&mipi 0x180>; /* DSIC & DSID pads */
Review the changes and make sure they are as expected. Edit the file again if necessary.

(Open file: )
(Current directory: /linux_swe_repo/code_base)
bash-$
2025-07-25 05:14:00,618 - INFO - swea-agent - ========================= STEP 12 =========================
```
