### PR TITLE
Fix broken references in markdown files

### DIFF
--- a/.github/workflows/check-links-periodic.yaml
+++ b/.github/workflows/check-links-periodic.yaml
@@ -5,7 +5,7 @@ on:
   push:
     branches:
       - main
-      - bala/fix_broken_links
+      - 0xba1a:bala/fix_broken_links
   schedule:
     - cron: "0 0 1 * *"
 

--- a/.github/workflows/check-links-periodic.yaml
+++ b/.github/workflows/check-links-periodic.yaml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-      - link-checker-test*
   schedule:
     - cron: "0 0 1 * *"
 

--- a/.github/workflows/check-links-periodic.yaml
+++ b/.github/workflows/check-links-periodic.yaml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+      - bala/fix_broken_links
   schedule:
     - cron: "0 0 1 * *"
 

--- a/.github/workflows/check-links-periodic.yaml
+++ b/.github/workflows/check-links-periodic.yaml
@@ -5,7 +5,7 @@ on:
   push:
     branches:
       - main
-      - 0xba1a:bala/fix_broken_links
+      - bala/fix_broken_links
   schedule:
     - cron: "0 0 1 * *"
 

--- a/docs/usage/batch_mode.md
+++ b/docs/usage/batch_mode.md
@@ -108,7 +108,7 @@ You'll see output that looks like this (only with 3 workers instead of 30):
 </figure>
 
 !!! tip "All command line options"
-    See [`RunBatchConfig`](../reference/run_batch_config.md/#sweagent.run.run_batch.RunBatchConfig) for an overview of all options.
+    See [`RunBatchConfig`](../reference/run_batch_config.md#sweagent.run.run_batch.RunBatchConfig) for an overview of all options.
 
 When starting a lot of parallel instances with the docker backend, it might happen that you see some bottleneck effects
 (e.g., when running on a platform with few CPUs, you might see some timeouts because there's not enough CPUs to handle the startup of all containers in time).

--- a/docs/usage/batch_mode.md
+++ b/docs/usage/batch_mode.md
@@ -45,8 +45,8 @@ Kind of slow, isn't it?
 
 
 !!! tip "All command line options"
-    * See [`RunBatchConfig`](../reference/run_batch_config.md/#sweagent.run.run_batch.RunBatchConfig) for an overview of all options.
-    * SWE-bench config: [`SWEBenchInstances`](../reference/batch_instances.md/#sweagent.run.batch_instances.SWEBenchInstances).
+    * See [`RunBatchConfig`](../reference/run_batch_config.md#sweagent.run.run_batch.RunBatchConfig) for an overview of all options.
+    * SWE-bench config: [`SWEBenchInstances`](../reference/batch_instances.md#sweagent.run.batch_instances.SWEBenchInstances).
 
 !!! tip "Evaluating on SWE-bench"
     If you are using [`sb-cli`](https://www.swebench.com/sb-cli/), you can automatically evaluate on SWE-bench by adding the `--evaluate=True` flag.
@@ -148,8 +148,8 @@ Here'the simplest example of what such a file can look like
     However, we temporarily support both names.
 
 !!! tip "More options"
-    * There's a few more fields that you can populate. See [`SimpleBatchInstances`](../reference/batch_instances.md/#sweagent.run.batch_instances.SimpleBatchInstance) for more information.
-    * For all command line options with this instance type, see [`InstancesFromFile`](../reference/batch_instances.md/#sweagent.run.batch_instances.InstancesFromFile).
+    * There's a few more fields that you can populate. See [`SimpleBatchInstances`](../reference/batch_instances.md#sweagent.run.batch_instances.SimpleBatchInstance) for more information.
+    * For all command line options with this instance type, see [`InstancesFromFile`](../reference/batch_instances.md#sweagent.run.batch_instances.InstancesFromFile).
 
 ## Huggingface instances
 
@@ -166,7 +166,7 @@ sweagent run-batch \
 ```
 
 !!! tip "All instance options"
-    See [`InstancesFromHuggingFace`](../reference/batch_instances.md/#sweagent.run.batch_instances.InstancesFromHuggingFace).
+    See [`InstancesFromHuggingFace`](../reference/batch_instances.md#sweagent.run.batch_instances.InstancesFromHuggingFace).
 
 ## Expert instances
 
@@ -204,7 +204,7 @@ where `instances.yaml` could look like this:
 ```
 
 !!! tip "All instance options"
-    See [`ExpertInstances`](../reference/batch_instances.md/#sweagent.run.batch_instances.ExpertInstancesFromFile).
+    See [`ExpertInstances`](../reference/batch_instances.md#sweagent.run.batch_instances.ExpertInstancesFromFile).
 
 ## Output files and next steps
 

--- a/docs/usage/coding_challenges.md
+++ b/docs/usage/coding_challenges.md
@@ -13,7 +13,7 @@ Let's start with a new problem statement. For this, put the problem you want to 
 <details>
 <summary>Example leetcode challenge</summary>
 
-This is the <a href="https://leetcode.com/problems/first-missing-positive/description/">first missing positive</a> challenge.
+This is the <a href="https://leetcode.com/problems/first-missing-positive/">first missing positive</a> challenge.
 
 ```markdown
 --8<-- "docs/usage/leetcode_example.md"

--- a/docs/usage/coding_challenges.md
+++ b/docs/usage/coding_challenges.md
@@ -13,7 +13,7 @@ Let's start with a new problem statement. For this, put the problem you want to 
 <details>
 <summary>Example leetcode challenge</summary>
 
-This is the <a href="https://leetcode.com/problems/first-missing-positive/">first missing positive</a> challenge.
+This is the <a href="https://leetcode.com/problems/first-missing-positive/description/">first missing positive</a> challenge.
 
 ```markdown
 --8<-- "docs/usage/leetcode_example.md"

--- a/mlc_config.json
+++ b/mlc_config.json
@@ -20,18 +20,6 @@
     },
     {
       "pattern": "https://linuxize.com/post/bash-heredoc/"
-    },
-    {
-      "pattern": "https://leetcode.com/problems/.*"
-    },
-    {
-      "pattern": ".*\\.md/#sweagent\\..*"
-    }
-  ],
-  "replacements": [
-    {
-      "pattern": "/#.*",
-      "replacement": ""
     }
   ]
 }

--- a/mlc_config.json
+++ b/mlc_config.json
@@ -20,6 +20,9 @@
     },
     {
       "pattern": "https://linuxize.com/post/bash-heredoc/"
+    },
+    {
+      "pattern": "https://leetcode.com/problems/.*"
     }
   ]
 }


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!
-->

#### Reference Issues/PRs
<!--
Example: "Fixes #1234", "See also #3456"
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### What does this implement/fix? Explain your changes.
<!--
Please include a brief explanation of how your solution
fixes the tagged issue(s), along with what files / entities have
been modified for this fix.
-->
Having a `/` after the filename in the anchor link of a markdown is not widely supported. Though these links were properly navigating in the GitHub web interface, they weren't when I tried in VSCode preview window. But removing the `/` made it work both places. Also, it fixes the errors reported by `markdown-link-check` GitHub Action.

The leetcode url was redirecting to a sub-route. Probably the link-checker isn't following redirections. So, replaced with the target url of the redirection.