### PR TITLE
Docs: Fix invalid argument `--env.image` in command example

### DIFF
--- a/docs/config/environments.md
+++ b/docs/config/environments.md
@@ -30,4 +30,4 @@ SHELL ["/bin/bash", "-c"]
 
 Build it with `docker build -f tiny.Dockerfile -t swe-agent-tiny .`.
 
-Now you can run it in the agent with `sweagent run --env.image swe-agent-tiny ...`
+Now you can run it in the agent with `sweagent run --env.deployment.image swe-agent-tiny ...`


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!
-->

#### Reference Issues/PRs
<!--
Example: "Fixes #1234", "See also #3456"
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
N/A 

#### What does this implement/fix? Explain your changes.
<!--
Please include a brief explanation of how your solution
fixes the tagged issue(s), along with what files / entities have
been modified for this fix.
-->
This pull request fixes an incorrect command-line argument in the documentation.

When running the example command, using `--env.image` results in a `RuntimeError: Invalid command line arguments.`. This can be confusing for new users trying to get started with `swe-agent`.

My change corrects the argument to `--env.deployment.image`, which is the valid argument and allows the command to execute successfully.

**Files Modified:**
*   `docs/config/environments.md`

This small fix improves the user experience by ensuring the provided examples work.