### PR TITLE
fix: update docker-in-docker feature reference in devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,7 +13,7 @@
     "onCreateCommand": "./.devcontainer/oncreate.sh",
     "postCreateCommand": "./.devcontainer/postcreate.sh",
     "features": {
-        "docker-in-docker": "latest"
+        "ghcr.io/devcontainers/features/docker-in-docker:2": {}
     },
     "mounts": [
         "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind"


### PR DESCRIPTION

<!--
Thanks for contributing a pull request!
-->

#### Reference Issues/PRs
<!--
Example: "Fixes #1234", "See also #3456"
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

Fixes #1272

#### What does this implement/fix? Explain your changes.
<!--
Please include a brief explanation of how your solution
fixes the tagged issue(s), along with what files / entities have
been modified for this fix.
-->

The docker-in-docker extension used in dev containers seems to be old, which causes a failure on extension installation, and then you can't use the dev environment. I am using the config alternative posted in https://github.com/devcontainers/features/tree/main/src/docker-in-docker.

This makes the dev container able to start
