### PR TITLE
Fix FunctionCallingParser

### DIFF
--- a/sweagent/tools/parsing.py
+++ b/sweagent/tools/parsing.py
@@ -420,13 +420,16 @@ class FunctionCallingParser(AbstractParseFunction, BaseModel):
             msg = f"Unexpected argument(s): {', '.join(extra_args)}"
             raise FunctionCallingFormatError(msg, "unexpected_arg")
 
-        def get_quoted_arg(value: Any) -> str:
+        def get_quoted_arg(value: Any) -> Any:
             if isinstance(value, str):
                 return quote(value) if _should_quote(value, command) else value
             # See https://github.com/SWE-agent/SWE-agent/issues/1159
             if value is None:
                 return ""
-            return value
+            # For lists and other non-string types, return as-is so Jinja2 filters work correctly
+            if isinstance(value, list):
+                return value
+            return str(value)
 
         formatted_args = {
             arg.name: Template(arg.argument_format).render(value=get_quoted_arg(values[arg.name]))


### PR DESCRIPTION
### The problem

My agent was trying to call the [str_replace_editor](https://github.com/SWE-agent/SWE-agent/blob/main/tools/edit_anthropic/bin/str_replace_editor) tool, ans epcifically, using the `--view_range` argument. The logs printed by the [agent](https://github.com/SWE-agent/SWE-agent/blob/main/sweagent/agent/agents.py#L1050) suggests a parsing error, e.g., 
```
str_replace_editor view /swesmith__keleshev__schema.24a30457/test_schema.py  --view_range [ 2 5 1 ,   3 1 6 ]
```
This is clearly because [when we format the view_range arguments](https://github.com/SWE-agent/SWE-agent/blob/main/tools/edit_anthropic/config.yaml#L55), we do a `join(' ')`. 

### The dig-into

To make sure this is the case, I put a breakpoint [around here](https://github.com/SWE-agent/SWE-agent/blob/main/sweagent/tools/parsing.py#L437).

---

(Pdb) command.invoke_format.format(**formatted_args).strip()
'str_replace_editor view /swesmith__andialbrecht__sqlparse.e57923b3/sqlparse/sql.py  --view_range [ 8 0 ,   1 0 0 ]'

(Pdb) command
Command(name='str_replace_editor', docstring='Custom editing tool for viewing, creating and editing files * State is persistent across command calls and discussions with the user * If `path` is a file, `view` displays the result of applying `cat -n`. If `path` is a directory, `view` lists non-hidden files and directories up to 2 levels deep * The `create` command cannot be used if the specified `path` already exists as a file * If a `command` generates a long output, it will be truncated and marked with `<response clipped>` * The `undo_edit` command will revert the last edit made to the file at `path`\nNotes for using the `str_replace` command: * The `old_str` parameter should match EXACTLY one or more consecutive lines from the original file. Be mindful of whitespaces! * If the `old_str` parameter is not unique in the file, the replacement will not be performed. Make sure to include enough context in `old_str` to make it unique * The `new_str` parameter should contain the edited lines that should replace the `old_str`\n', signature='str_replace_editor <command> <path> [<file_text>] [<view_range>] [<old_str>] [<new_str>] [<insert_line>]\n', end_name=None, arguments=[Argument(name='command', type='string', items=None, description='The commands to run. Allowed options are: `view`, `create`, `str_replace`, `insert`, `undo_edit`.', required=True, enum=['view', 'create', 'str_replace', 'insert', 'undo_edit'], argument_format='{{value}}'), Argument(name='path', type='string', items=None, description='Absolute path to file or directory, e.g. `/testbed/file.py` or `/testbed`.', required=True, enum=None, argument_format='{{value}}'), Argument(name='file_text', type='string', items=None, description='Required parameter of `create` command, with the content of the file to be created.', required=False, enum=None, argument_format='--file_text {{value}}'), Argument(name='old_str', type='string', items=None, description='Required parameter of `str_replace` command containing the string in `path` to replace.', required=False, enum=None, argument_format='--old_str {{value}}'), Argument(name='new_str', type='string', items=None, description='Optional parameter of `str_replace` command containing the new string (if not given, no string will be added). Required parameter of `insert` command containing the string to insert.', required=False, enum=None, argument_format='--new_str {{value}}'), Argument(name='insert_line', type='integer', items=None, description='Required parameter of `insert` command. The `new_str` will be inserted AFTER the line `insert_line` of `path`.', required=False, enum=None, argument_format='--insert_line {{value}}'), Argument(name='view_range', type='array', items={'type': 'integer'}, description='Optional parameter of `view` command when `path` points to a file. If none is given, the full file is shown. If provided, the file will be shown in the indicated line number range, e.g. [11, 12] will show lines 11 and 12. Indexing at 1 to start. Setting `[start_line, -1]` shows all lines from `start_line` to the end of the file.', required=False, enum=None, argument_format="--view_range {{value|join(' ')}}")])

(Pdb) formatted_args
{'command': 'view', 'path': '/swesmith__andialbrecht__sqlparse.e57923b3/sqlparse/sql.py', 'file_text': '', 'old_str': '', 'new_str': '', 'insert_line': '', 'view_range': '--view_range [ 8 0 ,   1 0 0 ]'}

(Pdb) values
{'command': 'view', 'path': '/swesmith__andialbrecht__sqlparse.e57923b3/sqlparse/sql.py', 'view_range': [80, 100]}

(Pdb) type(values["view_range"])
<class 'list'>

(Pdb) modified_formatted_args = {arg.name: Template(arg.argument_format).render(value=values[arg.name]) if arg.name in values else "" for arg in command.arguments}  # mimicking the behavior of not converting the `value` into string in `get_quoted_arg()`

(Pdb) command.invoke_format.format(**modified_formatted_args).strip()
'str_replace_editor view /swesmith__andialbrecht__sqlparse.e57923b3/sqlparse/sql.py  --view_range 80 100'

---

In the above example:
* `values["view_range"]` is `[80, 100]` (a list)
* But `get_quoted_arg()` converts it to a string: `str([80, 100]) = "[80, 100]"`
* Then when the Jinja2 template `--view_range {{value|join(' ')}}` is rendered with this string value, the `join(' ')` filter tries to join the characters of the string `"[80, 100]"`, which results in `"[ 8 0 ,   1 0 0 ]"`

### The fix

For lists (and other non-string types, maybe for future), return as-is so Jinja2 filters work correctly
