### PR TITLE
Add explicit `checkout` step

### DIFF
--- a/sweagent/environment/repo.py
+++ b/sweagent/environment/repo.py
@@ -29,9 +29,11 @@ class Repo(Protocol):
 
 def _get_git_reset_commands(base_commit: str) -> list[str]:
     return [
+        "git fetch",
         "git status",
         "git restore .",
-        f"git reset --hard {base_commit}",
+        "git reset --hard",
+        f"git checkout {base_commit}",
         "git clean -fdq",
     ]
 


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes https://github.com/SWE-bench/SWE-smith/issues/141

#### What does this implement/fix? Explain your changes.

Unlike SWE-bench style instances, where the a task instance's starting state for a codebase is configured by checking out a base commit at some prior point in the repository, in SWE-smith the bugs are stored are branches. However, the existing `git reset --hard {base_commit}` doesn't work for checking out a branch.

This PR makes a minor change to the setup script commands that adds an explicit `git checkout` which should work for both branches and past commits.