### PR TITLE
use docker.io prefix to pull image (for podman)

### DIFF
--- a/sweagent/run/batch_instances.py
+++ b/sweagent/run/batch_instances.py
@@ -175,7 +175,7 @@ class SimpleBatchInstance(BaseModel):
         if image_name is None:
             # Docker doesn't allow double underscore, so we replace them with a magic token
             id_docker_compatible = iid.replace("__", "_1776_")
-            image_name = f"swebench/sweb.eval.x86_64.{id_docker_compatible}:latest".lower()
+            image_name = f"docker.io/swebench/sweb.eval.x86_64.{id_docker_compatible}:latest".lower()
         extra_fields = {}
         if "image_assets" in instance:
             issue_images = json.loads(instance["image_assets"])["problem_statement"]

--- a/tests/test_batch_instance.py
+++ b/tests/test_batch_instance.py
@@ -16,7 +16,7 @@ def test_simple_batch_from_swe_bench_to_full_batch_instance(test_data_sources_pa
     assert isinstance(instance.env.repo, PreExistingRepoConfig)
     assert instance.env.repo.repo_name == "testbed"
     assert isinstance(instance.env.deployment, DockerDeploymentConfig)
-    assert instance.env.deployment.image == "swebench/sweb.eval.x86_64.pydicom_1776_pydicom-1458:latest"
+    assert instance.env.deployment.image == "docker.io/swebench/sweb.eval.x86_64.pydicom_1776_pydicom-1458:latest"
     assert isinstance(instance.problem_statement, TextProblemStatement)
     assert instance.problem_statement.text == sb_instance["problem_statement"]
     assert instance.problem_statement.id == "pydicom__pydicom-1458"


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!
-->

#### Reference Issues/PRs

Fixes https://github.com/SWE-agent/SWE-agent/issues/1290

I edited every image name that was not specific enough with adding `docker.io/` prefix. It should now work with podman.
