### PR TITLE
fix(tools): search_file matches wrong lines

### DIFF
--- a/tools/search/bin/search_file
+++ b/tools/search/bin/search_file
@@ -37,7 +37,7 @@ main() {
     local num_matches=$(echo "$matches" | wc -l | awk '{$1=$1; print $0}')
 
     # calculate total number of lines matched
-    local num_lines=$(echo "$matches" | cut -d: -f1 | sort | uniq | wc -l | awk '{$1=$1; print $0}')
+    local num_lines=$(echo "$matches" | cut -d: -f2 | sort | uniq | wc -l | awk '{$1=$1; print $0}')
     # if num_lines is > 100, print an error
     if [ $num_lines -gt 100 ]; then
         echo "More than $num_lines lines matched for \"$search_term\" in $file. Please narrow your search."


### PR DESCRIPTION
Example:
search_term: work
file: README.md
```
matches=$(echo "$matches" | cut -d: -f2)
```
num_lines=1 because cut extracts the filename instead of line number.

After fix:
```bash ./tools/search/bin/search_file \" sweagent/agent/agents.py
More than 296 lines matched for """ in /home/erickg/Dev/SWE-agent/sweagent/agent/agents.py. Please narrow your search.
```