### PR TITLE
fix: correct inverted logic in blocklist check

### DIFF
--- a/sweagent/tools/tools.py
+++ b/sweagent/tools/tools.py
@@ -355,7 +355,7 @@ class ToolHandler:
         action = action.strip()
         if not action:
             return False
-        if any(f.startswith(action) for f in self.config.filter.blocklist):
+        if any(action.startswith(f) for f in self.config.filter.blocklist):
             return True
         if action in self.config.filter.blocklist_standalone:
             return True


### PR DESCRIPTION
## Description

The `should_block_action` method in `ToolHandler` had inverted logic when checking the blocklist. It was checking if blocklist items start with the action, instead of checking if the action starts with blocklist items.

## The Bug

```python
# Before (incorrect)
if any(f.startswith(action) for f in self.config.filter.blocklist):
    return True
```

This checks if `'vim'` starts with `'vim test.py'` → **False** (command not blocked)

```python
# After (correct)  
if any(action.startswith(f) for f in self.config.filter.blocklist):
    return True
```

This checks if `'vim test.py'` starts with `'vim'` → **True** (command blocked ✓)

## Impact

Interactive commands like `vim`, `emacs`, `nano`, etc. that should be blocked were being allowed through, potentially causing the agent to hang when these commands are executed.

## Related Issue

Fixes #1316