### PR TITLE
feat: add private repository support for SWE-smith instances

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,10 +6,3 @@
 #   public_repo  - for public repos (read metadata, open PRs)
 #   repo         - for private repos (all of the above + private repo access)
 GITHUB_TOKEN=
-
-# Custom SSH key for private repo operations (optional)
-# If not set, the system looks for default keys in ~/.ssh/
-# (id_rsa, id_ecdsa, id_ecdsa_sk, id_ed25519, id_ed25519_sk)
-#
-# Set this only if your GitHub SSH key is at a non-standard path.
-# GITHUB_USER_SSH_KEY=/home/user/.ssh/id_ed25519_github

--- a/sweagent/environment/repo.py
+++ b/sweagent/environment/repo.py
@@ -6,7 +6,7 @@ from typing import Any, Literal, Protocol
 
 from git import InvalidGitRepositoryError
 from git import Repo as GitRepo
-from pydantic import BaseModel, ConfigDict, Field, SecretStr
+from pydantic import BaseModel, ConfigDict, Field
 from swerex.deployment.abstract import AbstractDeployment
 from swerex.runtime.abstract import Command, UploadRequest
 from typing_extensions import Self
@@ -192,16 +192,14 @@ class GithubRepoConfig(BaseModel):
 
 
 class SWESmithRepoConfig(BaseModel):
-    """Repository config for SWE-Smith instances that handles SSH key injection
-    and targeted fetch from a GitHub mirror.
+    """Repository config for SWE-Smith instances that handles targeted fetch
+    from a GitHub mirror, authenticating via GITHUB_TOKEN when needed.
     """
 
     repo_name: str
     base_commit: str = Field(default="HEAD")
     mirror_url: str = ""
-    """SSH URL of the GitHub mirror to fetch the bug branch from."""
-    ssh_key_b64: SecretStr = Field(default=SecretStr(""))
-    """Base64-encoded SSH private key for authenticating with the mirror."""
+    """HTTPS URL of the GitHub mirror to fetch the bug branch from."""
 
     type: Literal["swesmith_preexisting"] = "swesmith_preexisting"
     """Discriminator for (de)serialization/CLI. Do not change."""
@@ -211,33 +209,25 @@ class SWESmithRepoConfig(BaseModel):
     def copy(self, deployment: AbstractDeployment):
         pass
 
+    @staticmethod
+    def _get_url_with_token(url: str, token: str) -> str:
+        if not token or not url:
+            return url
+        _, _, url_no_protocol = url.partition("://")
+        return f"https://{token}@{url_no_protocol}"
+
     def get_reset_commands(self) -> list[str]:
-        commands: list[str] = []
-        key = self.ssh_key_b64.get_secret_value()
-
-        if key:
-            commands.extend(
-                [
-                    f"echo '{key}' | base64 -d > /tmp/github_key",
-                    "chmod 600 /tmp/github_key",
-                    "export GIT_SSH_COMMAND='ssh -i /tmp/github_key -o StrictHostKeyChecking=accept-new -o IdentitiesOnly=yes'",
-                ]
-            )
-
         if self.mirror_url:
-            commands.extend(
-                [
-                    "git restore .",
-                    "git reset --hard",
-                    f"git fetch {shlex.quote(self.mirror_url)} {shlex.quote(self.base_commit)}",
-                    "git checkout FETCH_HEAD",
-                    "git clean -fdq",
-                ]
-            )
-        else:
-            commands.extend(_get_git_reset_commands(self.base_commit))
-
-        return commands
+            github_token = os.getenv("GITHUB_TOKEN", "")
+            url = self._get_url_with_token(self.mirror_url, github_token)
+            return [
+                "git restore .",
+                "git reset --hard",
+                f"git fetch {shlex.quote(url)} {shlex.quote(self.base_commit)}",
+                "git checkout FETCH_HEAD",
+                "git clean -fdq",
+            ]
+        return _get_git_reset_commands(self.base_commit)
 
 
 RepoConfig = LocalRepoConfig | GithubRepoConfig | PreExistingRepoConfig | SWESmithRepoConfig

--- a/sweagent/utils/github.py
+++ b/sweagent/utils/github.py
@@ -1,9 +1,7 @@
-import base64
 import json
 import re
 import urllib.error
 import urllib.request
-from pathlib import Path
 
 from ghapi.all import GhApi
 
@@ -155,36 +153,3 @@ def _is_repo_private(owner_repo: str, token: str) -> bool:
             raise
     _repo_privacy_cache[owner_repo] = private
     return private
-
-
-def _find_and_encode_ssh_key() -> str:
-    """Find an SSH key from ``GITHUB_USER_SSH_KEY`` env var or default paths
-    and return its content as a base64-encoded string.
-
-    Lookup order:
-      1. Path specified by ``GITHUB_USER_SSH_KEY`` environment variable
-      2. ``~/.ssh/id_rsa``
-      3. ``~/.ssh/id_ecdsa``
-      4. ``~/.ssh/id_ecdsa_sk``
-      5. ``~/.ssh/id_ed25519``
-      6. ``~/.ssh/id_ed25519_sk``
-
-    Returns an empty string if no key is found.
-    """
-    import os
-
-    key_path_str = os.environ.get("GITHUB_USER_SSH_KEY")
-    if key_path_str:
-        key_path = Path(key_path_str)
-        if key_path.exists():
-            _logger.info("Using SSH key from GITHUB_USER_SSH_KEY: %s", key_path)
-            return base64.b64encode(key_path.read_bytes()).decode()
-
-    ssh_dir = Path.home() / ".ssh"
-    for key_name in ["id_rsa", "id_ecdsa", "id_ecdsa_sk", "id_ed25519", "id_ed25519_sk"]:
-        key_file = ssh_dir / key_name
-        if key_file.exists():
-            _logger.info("Using SSH key from %s", key_file)
-            return base64.b64encode(key_file.read_bytes()).decode()
-
-    return ""


### PR DESCRIPTION
## Summary

SWE-agent already supports cloning private repos via GITHUB_TOKEN in GithubRepoConfig. This PR addresses a different scenario: SWE-smith containers come with the repo pre-installed at /testbed, so there is no clone step. During environment reset, the container needs to fetch a specific bug-branch commit from the repo's private mirror — which requires SSH key injection into the reset commands.

- Adds SWESmithRepoConfig, a new repo type that handles SSH key injection and targeted fetch from private GitHub mirrors during environment reset
- Rewrites SWESmithInstances.get_instance_configs() to automatically detect private repos via the GitHub API and configure SSH-based git fetch when needed
- Adds _is_repo_private() and _find_and_encode_ssh_key() utilities to sweagent/utils/github.py
- Uses Pydantic SecretStr for SSH key storage, consistent with the existing api_key pattern in GenericAPIModelConfig
- Includes .env.example documenting the GITHUB_TOKEN and GITHUB_USER_SSH_KEY environment variables

## How it works

When loading SWE-smith task instances, each instance's repo field is checked against the GitHub API. If the repo is private (or returns 404), the loader:
1. Discovers an SSH key from GITHUB_USER_SSH_KEY env var or default ~/.ssh/ paths
2. Sets mirror_url to the SSH git URL of the private repo
3. During environment reset, SWESmithRepoConfig.get_reset_commands() injects the base64-decoded SSH key and fetches the bug branch from the mirror

Public repos continue to work as before with no SSH setup.
