### PR TITLE
Preserve full model message and reasoning_content to retain DeepSeek …

### DIFF
--- a/sweagent/agent/models.py
+++ b/sweagent/agent/models.py
@@ -773,12 +773,11 @@ class LiteLLMModel(AbstractModel):
                 # Ensure reasoning_content is preserved for DeepSeek interleaved thinking
                 if hasattr(raw, "reasoning_content"):
                     output_dict["reasoning_content"] = raw.reasoning_content
-            output_tokens += litellm.utils.token_counter(
-                text=output,
-                model=self.custom_tokenizer["identifier"] if self.custom_tokenizer is not None else self.config.name,
-                custom_tokenizer=self.custom_tokenizer,
-            )
-            if self.tools.use_function_calling:
+        output_tokens += litellm.utils.token_counter(
+                =output,
+            model=self.custom_tokenizer["identifier"] if self.custom_tokenizer is not None else self.config.name,
+                om_tokenizer=self.custom_tokenizer,
+                      if self.tools.use_function_calling:
                 if response.choices[i].message.tool_calls:  # type: ignore
                     tool_calls = [call.to_dict() for call in response.choices[i].message.tool_calls]  # type: ignore
                 else:


### PR DESCRIPTION
…chain of thought

Fixes #1333

This fix preserves the full raw message object returned by the model and explicitly copies reasoning_content when present. Uses to_dict() when available and falls back to previous behavior otherwise.

DeepSeek models return chain-of-thought via reasoning_content field, which was previously lost. This change ensures the complete message is retained for features like integrate-think.

<!--
Thanks for contributing a pull request!
-->

#### Reference Issues/PRs
<!--
Example: "Fixes #1234", "See also #3456"
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### What does this implement/fix? Explain your changes.
<!--
Please include a brief explanation of how your solution
fixes the tagged issue(s), along with what files / entities have
been modified for this fix.
-->
