### PR TITLE
Fix off-by-one line handling in insert action

### DIFF
--- a/tests/tools/test_insert_tool.py
+++ b/tests/tools/test_insert_tool.py
@@ -41,7 +41,7 @@ class InsertToolTest(unittest.TestCase):
                     with redirect_stdout(StringIO()):
                         insert_tool.main("inserted", 5)
 
-            self.assertEqual(target_file.read_text(), "1\n2\n3\n4\n5\ninserted\n6")
+            assert target_file.read_text() == "1\n2\n3\n4\n5\ninserted\n6"
 
 
 if __name__ == "__main__":

--- a/tests/tools/test_insert_tool.py
+++ b/tests/tools/test_insert_tool.py
@@ -1,0 +1,48 @@
+import json
+import os
+import unittest
+from contextlib import redirect_stdout
+from io import StringIO
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest import mock
+
+from tests.utils import make_python_tool_importable
+
+TOOLS_DIR = Path(__file__).resolve().parents[2] / "tools"
+
+make_python_tool_importable(TOOLS_DIR / "registry" / "lib" / "registry.py", "registry")
+make_python_tool_importable(TOOLS_DIR / "windowed" / "lib" / "windowed_file.py", "windowed_file")
+make_python_tool_importable(TOOLS_DIR / "windowed" / "lib" / "flake8_utils.py", "flake8_utils")
+make_python_tool_importable(TOOLS_DIR / "windowed_edit_replace" / "bin" / "insert", "insert_tool")
+
+import insert_tool  # type: ignore
+
+
+class InsertToolTest(unittest.TestCase):
+    def test_insert_after_requested_display_line(self) -> None:
+        with TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            env_file = tmp_path / ".swe-agent-env"
+            target_file = tmp_path / "example.py"
+            target_file.write_text("1\n2\n3\n4\n5\n6")
+            env_file.write_text(
+                json.dumps(
+                    {
+                        "CURRENT_FILE": str(target_file),
+                        "FIRST_LINE": "0",
+                        "WINDOW": "10",
+                    }
+                )
+            )
+
+            with mock.patch.dict(os.environ, {"SWE_AGENT_ENV_FILE": str(env_file)}, clear=True):
+                with mock.patch.object(insert_tool, "flake8", return_value=""):
+                    with redirect_stdout(StringIO()):
+                        insert_tool.main("inserted", 5)
+
+            self.assertEqual(target_file.read_text(), "1\n2\n3\n4\n5\ninserted\n6")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/windowed_edit_replace/bin/insert
+++ b/tools/windowed_edit_replace/bin/insert
@@ -1,10 +1,9 @@
 #!/usr/bin/env python3
 
 import argparse
-from typing import Union
 
-from windowed_file import FileNotOpened, WindowedFile  # type: ignore
 from flake8_utils import flake8, format_flake8_output  # type: ignore
+from windowed_file import FileNotOpened, WindowedFile  # type: ignore
 
 RETRY_WITH_OUTPUT_TOKEN = "###SWE-AGENT-RETRY-WITH-OUTPUT###"
 
@@ -37,7 +36,7 @@ def get_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def main(text: str, line: Union[int, None] = None):
+def main(text: str, line: int | None = None):
     try:
         wf = WindowedFile(exit_on_exception=False)
     except FileNotOpened:

--- a/tools/windowed_edit_replace/bin/insert
+++ b/tools/windowed_edit_replace/bin/insert
@@ -46,7 +46,7 @@ def main(text: str, line: Union[int, None] = None):
         exit(1)
 
     pre_edit_lint = flake8(wf.path)
-    insert_info = wf.insert(text, line=line - 1 if line is not None else None)
+    insert_info = wf.insert(text, line=line if line is not None else None)
     post_edit_lint = flake8(wf.path)
 
     # Try to filter out pre-existing errors


### PR DESCRIPTION
## Summary
- stop subtracting 1 from the user-provided line number in the insert tool
- add a regression test covering insertion after the requested display line

## Why this is a local code issue
The bug comes from tools/windowed_edit_replace/bin/insert converting the CLI line number before calling WindowedFile.insert(). WindowedFile.insert() already handles the line index expected by the tool layer, so the extra - 1 shifts insertion one line too early.

## Validation
- python3 -m unittest tests.tools.test_insert_tool
- python3 -m py_compile tools/windowed_edit_replace/bin/insert tests/tools/test_insert_tool.py

Fixes #1331