### PR TITLE
Fix off-by-one error in insert action

### DIFF
--- a/tools/windowed_edit_replace/bin/insert
+++ b/tools/windowed_edit_replace/bin/insert
@@ -46,7 +46,7 @@ def main(text: str, line: Union[int, None] = None):
         exit(1)
 
     pre_edit_lint = flake8(wf.path)
-    insert_info = wf.insert(text, line=line - 1 if line is not None else None)
+    insert_info = wf.insert(text, line=line if line is not None else None)
     post_edit_lint = flake8(wf.path)
 
     # Try to filter out pre-existing errors


### PR DESCRIPTION
## Summary
- Fixes the off-by-one error in `tools/windowed_edit_replace/bin/insert` where `line=line - 1` caused the insert command to insert content after `line - 1` instead of after the specified `line`.
- Changed `line=line - 1 if line is not None else None` to `line=line if line is not None else None` on line 49.

Fixes #1331

## Test plan
- [ ] Verify that `insert` now inserts content after the correct line number
- [ ] Run existing test suite to ensure no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)