### PR TITLE
Fix insert action off-by-one error

### DIFF
--- a/tools/windowed_edit_replace/bin/insert
+++ b/tools/windowed_edit_replace/bin/insert
@@ -46,7 +46,7 @@ def main(text: str, line: Union[int, None] = None):
         exit(1)
 
     pre_edit_lint = flake8(wf.path)
-    insert_info = wf.insert(text, line=line - 1 if line is not None else None)
+    insert_info = wf.insert(text, line=line if line is not None else None)
     post_edit_lint = flake8(wf.path)
 
     # Try to filter out pre-existing errors


### PR DESCRIPTION
## Summary

- Fix off-by-one error in the `insert` command where content was inserted after line N-1 instead of after line N
- The bug was in `tools/windowed_edit_replace/bin/insert` line 49, which incorrectly subtracted 1 from the user-provided line number before passing it to `WindowedFile.insert()`
- The command's own documentation states the line parameter is "the line number to insert the text as new lines after", confirming the subtraction was wrong

## Details

`list.insert(i, x)` in Python inserts *before* position `i`. When the file's lines are split into a 0-indexed list, inserting at index `line` (1-indexed from the user) correctly places content after that line. The `line - 1` was causing insertion one line too early.

Fixes #1331

## Test plan

- [ ] Open a file, run `insert "new content" 5`, verify content appears after line 5 (not after line 4)
- [ ] Test `insert "text"` without a line number still appends to end of file
- [ ] Test `insert "text" 0` still inserts at the beginning of the file

🤖 Generated with [Claude Code](https://claude.com/claude-code)