### PR TITLE
Fix HumanModel total_cost_limit checking instance_cost instead of global total

### DIFF
--- a/sweagent/agent/models.py
+++ b/sweagent/agent/models.py
@@ -374,11 +374,13 @@ class HumanModel(AbstractModel):
     ) -> None:
         self.stats.instance_cost += self.config.cost_per_call
         self.stats.api_calls += 1
+        with GLOBAL_STATS_LOCK:
+            GLOBAL_STATS.total_cost += self.config.cost_per_call
         if 0 < self.config.per_instance_cost_limit < self.stats.instance_cost:
             msg = f"Instance cost limit exceeded: {self.stats.instance_cost} > {self.config.per_instance_cost_limit}"
             raise InstanceCostLimitExceededError(msg)
-        if 0 < self.config.total_cost_limit < self.stats.instance_cost:
-            msg = f"Total cost limit exceeded: {self.stats.instance_cost} > {self.config.total_cost_limit}"
+        if 0 < self.config.total_cost_limit < GLOBAL_STATS.total_cost:
+            msg = f"Total cost limit exceeded: {GLOBAL_STATS.total_cost} > {self.config.total_cost_limit}"
             raise TotalCostLimitExceededError(msg)
 
     def _query(


### PR DESCRIPTION
## Summary

`HumanModel._update_stats` (line 380) checks `total_cost_limit` against `self.stats.instance_cost` (per-instance cost), but `total_cost_limit` is meant to cap cumulative cost across all instances. The correct variable is `GLOBAL_STATS.total_cost`, as used in `LiteLLMModel._update_stats` (line 655).

Additionally, `HumanModel` never updates `GLOBAL_STATS.total_cost`, so the global accumulator stays at 0 for human-model runs.

**Fix:**
1. Add `GLOBAL_STATS.total_cost += self.config.cost_per_call` (under `GLOBAL_STATS_LOCK`, matching `LiteLLMModel`)
2. Check `GLOBAL_STATS.total_cost` instead of `self.stats.instance_cost` for the total cost limit

## Test plan

- [ ] Run `HumanModel` with `cost_per_call > 0` and a low `total_cost_limit` — should now correctly raise `TotalCostLimitExceededError` when global total exceeds the limit
- [ ] Verify `per_instance_cost_limit` behavior is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)