### PR TITLE
Fix communicate() always passing 'silent' to swerex regardless of check mode

### DIFF
--- a/sweagent/environment/swe_env.py
+++ b/sweagent/environment/swe_env.py
@@ -216,7 +216,7 @@ class SWEEnv:
             output: output from container
         """
         self.logger.log(logging.TRACE, "Input:\n%s", input)  # type: ignore
-        rex_check = "silent" if check else "ignore"
+        rex_check = "silent" if check != "ignore" else "ignore"
         r = asyncio.run(
             self.deployment.runtime.run_in_session(BashAction(command=input, timeout=timeout, check=rex_check))
         )


### PR DESCRIPTION
## Bug

In `SWEEnv.communicate()`, the swerex check mode is computed as:

```python
rex_check = "silent" if check else "ignore"
```

`check` has type `Literal["warn", "ignore", "raise"]`. All three string values are truthy in Python, so `rex_check` is **always** `"silent"`, never `"ignore"`.

When `check="ignore"` (the default, used in agent execution at line 966), the docstring says: *"do not extract exit code (more stable)"*. The intent is to pass `"ignore"` to swerex so it skips exit code extraction entirely. Instead, `"silent"` is passed, which still extracts the exit code but suppresses errors — a different and less stable behavior.

## Fix

```python
rex_check = "silent" if check != "ignore" else "ignore"
```

This correctly maps:
- `check="ignore"` → `rex_check="ignore"` (skip exit code extraction)
- `check="warn"` or `check="raise"` → `rex_check="silent"` (extract exit code silently, let SWEEnv handle it on line 225)

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>