### PR TITLE
Fix broken human-model check in RunBatch (._model_id never matched)

### DIFF
--- a/sweagent/run/run_batch.py
+++ b/sweagent/run/run_batch.py
@@ -160,6 +160,7 @@ class RunBatch:
                 times the number of workers at the start of each instance. This is to avoid any
                 potential race conditions.
         """
+        self.agent_config = agent_config
         if self._model_id in ["human", "human_thought"] and num_workers > 1:
             msg = "Cannot run with human model in parallel"
             raise ValueError(msg)
@@ -171,7 +172,6 @@ class RunBatch:
             filter=lambda name: "swea-run" in name or "config" in name,
         )
         self.instances = instances
-        self.agent_config = agent_config
         self.output_dir = output_dir
         self._raise_exceptions = raise_exceptions
         self._chooks = CombinedRunHooks()
@@ -188,7 +188,7 @@ class RunBatch:
     @property
     def _model_id(self) -> str:
         try:
-            return self.agent_config.model.id  # type: ignore[attr-defined]
+            return self.agent_config.model.name  # type: ignore[attr-defined]
         except AttributeError:
             return "unknown"
 


### PR DESCRIPTION
## Bug

Two checks in \`sweagent/run/run_batch.py\` that are supposed to special-case the human models have silently stopped working:

1. \`RunBatch.__init__\` (line 163):

    \`\`\`python
    if self._model_id in [\"human\", \"human_thought\"] and num_workers > 1:
        msg = \"Cannot run with human model in parallel\"
        raise ValueError(msg)
    \`\`\`

    is supposed to refuse parallel human runs — it never fires.

2. \`RunBatch.main_single_worker\` (line 259):

    \`\`\`python
    if self._model_id not in [\"human\", \"human_thought\"] and self._show_progress_bar:
        stack.enter_context(Live(self._progress_manager.render_group))
    \`\`\`

    is supposed to suppress the rich `Live` progress bar while a human is typing — it always enters the `Live` context, even for human models.

## Root cause

Both call sites rely on \`self._model_id\`:

\`\`\`python
@property
def _model_id(self) -> str:
    try:
        return self.agent_config.model.id  # type: ignore[attr-defined]
    except AttributeError:
        return \"unknown\"
\`\`\`

Two independent issues combine to break the checks:

1. In \`RunBatch.__init__\`, \`self._model_id\` is read **before** \`self.agent_config = agent_config\` runs (the assignment is ~12 lines later). So the property's \`except AttributeError\` branch fires and returns \`\"unknown\"\` — the parallel-human guard never triggers, regardless of the configured model.

2. \`GenericAPIModelConfig.id\` is defined as

    \`\`\`python
    f\"{name}__t-{temperature:.2f}__p-{top_p:.2f}__c-{per_instance_cost_limit:.2f}\"
    \`\`\`

    For \`HumanModelConfig\` (\`name=\"human\"\`) this evaluates to something like \`\"human__t-0.00__p-1.00__c-0.00\"\`, which can never be \`==\` to \`\"human\"\` or \`\"human_thought\"\`. So even when \`agent_config\` *is* set (the \`main_single_worker\` check on line 259), the \`in [...]\` test is always false for human models and the \`Live\` progress bar is wrongly drawn over the interactive prompt.

The original pre-#777e4b565 code compared \`agent_config.model.name\` against the same \`[\"human\", \"human_thought\"]\` list, which is the correct field — \`HumanModelConfig.name = \"human\"\` and \`HumanThoughtModelConfig.name = \"human_thought\"\` are the exact literals the check uses.

## Fix

Two minimal changes, both preserving the existing \`_model_id\` abstraction:

\`\`\`diff
+        self.agent_config = agent_config
         if self._model_id in [\"human\", \"human_thought\"] and num_workers > 1:
             msg = \"Cannot run with human model in parallel\"
             raise ValueError(msg)
\`\`\`

…so the property has \`self.agent_config\` available when the \`__init__\` guard runs, and:

\`\`\`diff
     @property
     def _model_id(self) -> str:
         try:
-            return self.agent_config.model.id  # type: ignore[attr-defined]
+            return self.agent_config.model.name  # type: ignore[attr-defined]
         except AttributeError:
             return \"unknown\"
\`\`\`

…so the property returns the bare name literal that both usage sites compare against.

Both call sites of \`_model_id\` (lines 163 and 259) only ever compare to \`[\"human\", \"human_thought\"]\`, so returning \`.name\` instead of the composite \`.id\` is the semantically-correct change and doesn't affect any other behavior.