### PR TITLE
Fix inverted guard replacing caller's actions config with defaults

### DIFF
--- a/sweagent/run/run_single.py
+++ b/sweagent/run/run_single.py
@@ -149,7 +149,7 @@ class RunSingle:
         self.agent = agent
         self.output_dir = output_dir
         self._hooks = []
-        if actions is not None:
+        if actions is None:
             actions = RunSingleActionConfig()
         self.actions = actions
         self._chooks = CombinedRunHooks()


### PR DESCRIPTION
## Summary

In `RunSingle.__init__`, the guard on line 152 is inverted:

```python
if actions is not None:        # should be: is None
    actions = RunSingleActionConfig()
self.actions = actions
```

When a caller passes a real `RunSingleActionConfig` (e.g., with `open_pr=True` or `apply_patch_locally=True` from `from_config()`), it is replaced with a blank default, silently discarding all settings. When no actions are passed (`None`), `self.actions` stays `None`, causing `AttributeError` when hooks later access `self.actions.apply_patch_locally`.

**Fix:** Change `is not None` to `is None`.

## Test plan

- [x] Verified `from_config` passes `actions=config.actions` which gets discarded by the current code
- [x] Verified downstream code accesses `self.actions.apply_patch_locally` (would crash if None)
- [ ] Existing tests should continue to pass

🤖 Generated with [Claude Code](https://claude.ai/claude-code)