### PR TITLE
Fix block_unless_regex for r2 matching wrong command name

### DIFF
--- a/sweagent/tools/tools.py
+++ b/sweagent/tools/tools.py
@@ -67,7 +67,7 @@ class ToolFilterConfig(BaseModel):
 
     block_unless_regex: dict[str, str] = {
         "radare2": r"\b(?:radare2)\b.*\s+-c\s+.*",
-        "r2": r"\b(?:radare2)\b.*\s+-c\s+.*",
+        "r2": r"\b(?:r2)\b.*\s+-c\s+.*",
     }
     """Block any command that matches one of these names unless it also matches the regex"""
 


### PR DESCRIPTION
## Bug

In `ToolFilterConfig.block_unless_regex`, the `r2` entry uses the regex `\b(?:radare2)\b.*\s+-c\s+.*` — which looks for the word `radare2`, not `r2`:

```python
block_unless_regex: dict[str, str] = {
    "radare2": r"\b(?:radare2)\b.*\s+-c\s+.*",
    "r2": r"\b(?:radare2)\b.*\s+-c\s+.*",  # bug: matches "radare2" not "r2"
}
```

When `should_block_action` processes a command like `r2 -c 'cmd'`, it extracts `r2` as the command name, finds it in the dict, but the regex never matches because the action contains `r2`, not `radare2`. Result: `r2` is always blocked, even with the required `-c` flag.

## Root cause

Copy-paste error from the `radare2` entry — the regex word boundary was not updated.

## Fix

Change `\b(?:radare2)\b` → `\b(?:r2)\b` in the `r2` entry.

🤖 Generated with [Claude Code](https://claude.ai/code)