### PR TITLE
Fix repeated word in README warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 > [!warning]
 > Most of our current development effort is on [mini-swe-agent](https://github.com/SWE-agent/mini-swe-agent/),
-> which has superseded SWE-agent. It matches the performance performance of SWE-agent, while being
+> which has superseded SWE-agent. It matches the performance of SWE-agent, while being
 > much simpler.
 > See the [FAQ](https://mini-swe-agent.com/latest/faq/) for more details about the differences.
 > Our general recommendation is to use mini-SWE-agent instead of SWE-agent going forward.


### PR DESCRIPTION
This pull request corrects a small typo in the `README.md` file, fixing a repeated word in the description of `mini-swe-agent`.

<!--
Thanks for contributing a pull request!
-->

#### Reference Issues/PRs
<!--
Example: "Fixes #1234", "See also #3456"
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### What does this implement/fix? Explain your changes.
<!--
Please include a brief explanation of how your solution
fixes the tagged issue(s), along with what files / entities have
been modified for this fix.
-->
