### PR TITLE
Fix _guard_multiline_input slicing match_action with rem_action-relative indices

### DIFF
--- a/sweagent/tools/utils.py
+++ b/sweagent/tools/utils.py
@@ -24,7 +24,7 @@ def _guard_multiline_input(action: str, match_fct: Callable[[str], re.Match | No
             if match_action.strip():
                 eof = first_match.group(3).strip()
                 if not match_action.split("\n")[0].strip().endswith(f"<< '{eof}'"):
-                    guarded_command = match_action[first_match.start() :]
+                    guarded_command = match_action
                     first_line = guarded_command.split("\n")[0]
                     guarded_command = guarded_command.replace(first_line, first_line + f" << '{eof}'", 1)
                     parsed_action.append(guarded_command)


### PR DESCRIPTION
## Bug

When a multi-line command is preceded by any non-empty text in the same action string, \`_guard_multiline_input\` in \`sweagent/tools/utils.py\` drops the first \`first_match.start()\` characters of that command and emits a malformed heredoc to bash.

## Root cause

Inside the loop:

\`\`\`python
first_match = match_fct(rem_action)
...
pre_action = rem_action[: first_match.start()]
match_action = rem_action[first_match.start() : first_match.end()]
rem_action = rem_action[first_match.end() :]
...
if not match_action.split(\"\\n\")[0].strip().endswith(f\"<< '{eof}'\"):
    guarded_command = match_action[first_match.start() :]
    first_line = guarded_command.split(\"\\n\")[0]
    guarded_command = guarded_command.replace(first_line, first_line + f\" << '{eof}'\", 1)
    parsed_action.append(guarded_command)
\`\`\`

\`match_action\` is already the substring that \`first_match\` covers — by construction it starts at position 0 inside itself. The line \`guarded_command = match_action[first_match.start() :]\` treats \`first_match.start()\` (an index into \`rem_action\`) as if it were an index into \`match_action\`, which silently crops the beginning of the command whenever the preceding text (\`pre_action\`) is non-empty.

Consequences for a single action that contains prose before a multi-line tool call (a very common model output shape):

- The cropped prefix never makes it into \`parsed_action\` / the emitted bash.
- The \`first_line\` the code then decorates with \` << 'EOF'\` is **not** the actual command line, but whatever remains after the crop — typically somewhere in the middle of the real first line. Bash receives a heredoc attached to the wrong token, or no valid heredoc at all.

When \`first_match.start() == 0\` (there is no prose before the command), the slice happens to be a no-op, which is why the bug went unnoticed.

## Fix

Use \`match_action\` directly instead of re-slicing it with a \`rem_action\`-relative index:

\`\`\`diff
-                    guarded_command = match_action[first_match.start() :]
+                    guarded_command = match_action
\`\`\`

This restores the full matched command, lets the subsequent \`split(\"\\n\")[0]\` pick the real first line, and produces a well-formed \`… << 'EOF'\` heredoc. Behaviour is unchanged for the previously-working \`first_match.start() == 0\` case.