### PR TITLE
Forward thinking_blocks through CombinedAgentHook to sub-hooks

### DIFF
--- a/sweagent/agent/hooks/abstract.py
+++ b/sweagent/agent/hooks/abstract.py
@@ -46,6 +46,7 @@ class AbstractAgentHook:
         action: str = "",
         tool_calls: list[dict[str, str]] | None = None,
         tool_call_ids: list[str] | None = None,
+        thinking_blocks: list[dict[str, str]] | None = None,
     ): ...
 
     def on_setup_done(self): ...
@@ -129,6 +130,7 @@ class CombinedAgentHook(AbstractAgentHook):
                 action=action,
                 tool_calls=tool_calls,
                 tool_call_ids=tool_call_ids,
+                thinking_blocks=thinking_blocks,
             )
 
     def on_setup_done(self):


### PR DESCRIPTION
## Bug

\`CombinedAgentHook.on_query_message_added\` accepts a \`thinking_blocks\` kwarg in its signature but never passes it on to the registered hooks:

\`\`\`python
def on_query_message_added(
    self,
    *,
    agent: str,
    role: str,
    ...
    tool_call_ids: list[str] | None = None,
    thinking_blocks: list[dict[str, str]] | None = None,
):
    for hook in self.hooks:
        hook.on_query_message_added(
            agent=agent,
            role=role,
            ...
            tool_call_ids=tool_call_ids,
        )  # ← thinking_blocks is dropped here
\`\`\`

## Root cause

\`DefaultAgent._append_history\` invokes the dispatcher with \`self._chook.on_query_message_added(**item)\`, and the entry built in \`agents.py:716-727\` includes \`\"thinking_blocks\": step.thinking_blocks\`. The dispatcher accepts the kwarg so the call doesn't raise on its surface, but the per-hook fan-out omits it, leaving every registered sub-hook unable to observe the model's thinking blocks. The base class signature also lacks the parameter, so the dispatcher's API is the only place it appears.

## Fix

Add \`thinking_blocks\` to \`AbstractAgentHook.on_query_message_added\` (so the documented contract matches the dispatcher) and forward the value in the for-loop. Now every sub-hook gets the same kwarg the dispatcher was called with.