### PR TITLE
Fix Chooser.choose UnboundLocalError when model query raises

### DIFF
--- a/sweagent/agent/reviewer.py
+++ b/sweagent/agent/reviewer.py
@@ -356,6 +356,7 @@ class Chooser:
                 self.logger.error("Preselector must have failed, ignoring it.")
         messages = self.build_messages(problem_statement, [input[i] for i in selected_indices])
         chosen_idx = None
+        response = ""
         try:
             response = self.model.query(messages)["message"]  # type: ignore
             chosen_idx = self.interpret(response)


### PR DESCRIPTION
## Bug

`Chooser.choose` in `sweagent/agent/reviewer.py` assigns `response` inside a `try` block and then references it unconditionally on return:

```python
messages = self.build_messages(problem_statement, [input[i] for i in selected_indices])
chosen_idx = None
try:
    response = self.model.query(messages)["message"]
    chosen_idx = self.interpret(response)
except Exception as e:
    self.logger.critical(f"Chooser failed: {e}", exc_info=True)
    chosen_idx = None
if chosen_idx is None or not (0 <= chosen_idx < len(selected_indices)):
    self.logger.error(f"Invalid chosen index: {chosen_idx}, using first index")
    chosen_idx = selected_indices[0]
else:
    chosen_idx = selected_indices[chosen_idx]
return ChooserOutput(
    chosen_idx=chosen_idx, response=response, preselector_output=preselector_output, messages=messages
)
```

## Root cause

If `self.model.query(messages)` itself raises before the assignment (network timeout, rate-limit, litellm decode error, etc.), `response` is never bound. The broad `except` catches the error, logs "Chooser failed", and falls through. The subsequent `return ChooserOutput(..., response=response, ...)` then raises `UnboundLocalError: local variable 'response' referenced before assignment`, masking the original failure with a traceback far from the query site.

`Preselector.choose` (same file, line 282-289) has the same `self.model.query(...)` call but inside a separate try with the response only used inside, so it's unaffected.

## Fix

Initialize `response = ""` before the try block so the empty-string default survives a query failure and the logged "Chooser failed" message is what the caller actually sees, instead of the unrelated `UnboundLocalError`. Behavior on the success path is unchanged — the first line of the try block overwrites the default before any read.