### PR TITLE
Fix CombinedAgentHook.on_setup_done not dispatching to sub-hooks

### DIFF
--- a/sweagent/agent/hooks/abstract.py
+++ b/sweagent/agent/hooks/abstract.py
@@ -132,7 +132,8 @@ class CombinedAgentHook(AbstractAgentHook):
             )
 
     def on_setup_done(self):
-        return super().on_setup_done()
+        for hook in self.hooks:
+            hook.on_setup_done()
 
     def on_tools_installation_started(self):
         for hook in self.hooks:


### PR DESCRIPTION
## Bug

Every method on `CombinedAgentHook` in `sweagent/agent/hooks/abstract.py` is a fan-out over `self.hooks` — except `on_setup_done`:

```python
def on_setup_done(self):
    return super().on_setup_done()
```

`super().on_setup_done()` resolves to `AbstractAgentHook.on_setup_done` (body `...`), so the call is a no-op. None of the registered sub-hooks are notified.

## Root cause

`DefaultAgent._setup` calls `self._chook.on_setup_done()` (`sweagent/agent/agents.py:606`). The dispatcher was supposed to forward to each registered hook the same way `on_init`, `on_run_start`, `on_step_start`, `on_actions_generated`, `on_action_started`, `on_action_executed`, `on_step_done`, `on_run_done`, `on_setup_attempt`, `on_model_query`, `on_query_message_added`, and `on_tools_installation_started` all do. Copy-paste miss — the implementation went to `super()` instead of iterating `self.hooks`.

No current hook overrides `on_setup_done`, so the regression is latent today, but any future hook that implements it will be silently skipped.

## Fix

Replace the `super()` call with the same iteration used by every peer method:

```python
def on_setup_done(self):
    for hook in self.hooks:
        hook.on_setup_done()
```