### PR TITLE
Fix FunctionCallingParser UnboundLocalError when tool_call arguments are already a dict

### DIFF
--- a/sweagent/tools/parsing.py
+++ b/sweagent/tools/parsing.py
@@ -406,6 +406,8 @@ class FunctionCallingParser(AbstractParseFunction, BaseModel):
             except json.JSONDecodeError:
                 msg = "Tool call arguments are not valid JSON."
                 raise FunctionCallingFormatError(msg, "invalid_json")
+        else:
+            values = tool_call["function"]["arguments"]
         required_args = {arg.name for arg in command.arguments if arg.required}
         missing_args = required_args - values.keys()
         if missing_args:


### PR DESCRIPTION
## Bug

\`sweagent/tools/parsing.py:FunctionCallingParser._parse_tool_call\` assumes every LiteLLM-shaped tool_call carries its arguments as a JSON string, and only binds \`values\` inside the string-decoding branch:

\`\`\`python
if not isinstance(tool_call[\"function\"][\"arguments\"], dict):
    try:
        values = json.loads(tool_call[\"function\"][\"arguments\"])
    except json.JSONDecodeError:
        msg = \"Tool call arguments are not valid JSON.\"
        raise FunctionCallingFormatError(msg, \"invalid_json\")
required_args = {arg.name for arg in command.arguments if arg.required}
missing_args = required_args - values.keys()
\`\`\`

When \`arguments\` is already a \`dict\` (the \`isinstance\` check is exactly there to allow this), the block is skipped, \`values\` is never assigned, and the next line raises:

\`\`\`
UnboundLocalError: local variable 'values' referenced before assignment
\`\`\`

## Root cause

The \`isinstance(..., dict)\` guard is set up to short-circuit the JSON parse when the provider already hands back a structured dict — but the else branch that should bind \`values\` to that dict is missing.

## Why the fix is correct

Adding the missing \`else\` binds \`values\` to the pre-parsed dict, so the downstream \`values.keys()\` / \`set(values.keys())\` and \`values[arg.name]\` uses work identically regardless of whether the provider serialized arguments as a JSON string or as a dict. The JSON-string path (and its \`FunctionCallingFormatError\` on decode failure) is untouched.