### PR TITLE
Fix PatchFormatter.format_file off-by-one in 'lines below omitted' tail

### DIFF
--- a/sweagent/utils/patch_formatter.py
+++ b/sweagent/utils/patch_formatter.py
@@ -88,9 +88,9 @@ class PatchFormatter:
             else:
                 out.append("\n".join(these_lines))
             last_stop = stop
-        if last_stop < len(lines):
+        if last_stop <= len(lines):
             # Stop is not inclusive
-            omitted = len(lines) - last_stop
+            omitted = len(lines) - last_stop + 1
             assert omitted > 0
             out.append(f"[{omitted} lines below omitted]")
         return "\n".join(out)


### PR DESCRIPTION
## Bug

`PatchFormatter.format_file` (in `sweagent/utils/patch_formatter.py`) slices each hunk with `lines[start - 1 : stop - 1]`, with the docstring stating *"stop is not inclusive"*. Under that half-open convention, `last_stop` after a hunk points at the first line that was **not** printed. The between-hunk branch already uses that convention correctly:

```python
n_omitted = start - last_stop  # first-unprinted next_start minus first-unprinted here
```

The trailing "below omitted" branch, however, is written as if `last_stop` were the last-printed line:

```python
if last_stop < len(lines):
    # Stop is not inclusive
    omitted = len(lines) - last_stop
    out.append(f"[{omitted} lines below omitted]")
```

Two off-by-one bugs fall out of that:

1. **Missed marker.** When `last_stop == len(lines)`, line `len(lines)` is still unprinted (stop is exclusive) but `len(lines) < len(lines)` is `False`, so the `[N lines below omitted]` marker is suppressed entirely. The reader thinks the excerpt reaches end-of-file when it does not.
2. **Wrong count.** When `last_stop < len(lines)`, the reported number is one short. For a 15-line file with `last_stop = 10`, the omitted lines are 10, 11, 12, 13, 14, 15 (six lines), but the marker reads `"5 lines below omitted"`.

The "above" marker (`starts[0] - 1`) and "between" marker (`start - last_stop`) both use the correct half-open math — only the "below" branch mismatches.

## Fix

Switch the condition to `<=` and add the `+ 1` so the math lines up with the half-open convention:

```diff
-        if last_stop < len(lines):
+        if last_stop <= len(lines):
             # Stop is not inclusive
-            omitted = len(lines) - last_stop
+            omitted = len(lines) - last_stop + 1
             assert omitted > 0
             out.append(f"[{omitted} lines below omitted]")
```

- `last_stop == len(lines) + 1` (everything printed to EOF): condition `len+1 <= len` is `False`, no marker — unchanged, and now correct for the boundary too.
- `last_stop == len(lines)`: condition `True`, omitted = 1 — was previously suppressed; now correctly says `"1 line below omitted"`.
- `last_stop < len(lines)`: omitted = `len - last_stop + 1`, which matches the actual count (`[last_stop, len(lines)]` inclusive).
- `assert omitted > 0` still holds: the branch only runs when `last_stop <= len(lines)`, so `len(lines) - last_stop + 1 >= 1`.

Two line edits, no other changes.