### PR TITLE
Log all searched directories when merge_predictions finds nothing

### DIFF
--- a/sweagent/run/merge_predictions.py
+++ b/sweagent/run/merge_predictions.py
@@ -25,7 +25,7 @@ def merge_predictions(directories: list[Path], output: Path | None = None) -> No
         logger.debug("Found %d predictions in %s", len(new), directory)
     logger.info("Found %d predictions", len(preds))
     if not preds:
-        logger.warning("No predictions found in %s", directory)
+        logger.warning("No predictions found in %s", directories)
         return
     if output is None:
         output = directories[0] / "preds.json"


### PR DESCRIPTION
## Bug

`merge_predictions` logs the wrong (and sometimes undefined) value in
its "no predictions found" warning:

```python
preds = []
for directory in directories:
    ...
logger.info("Found %d predictions", len(preds))
if not preds:
    logger.warning("No predictions found in %s", directory)
    return
```

## Root cause

The warning references the loop variable `directory`, which has two
problems:

1. When multiple directories are searched, `directory` is the
   **last** one iterated. Users passing multiple dirs see a message
   that names only one, hiding the others they actually searched.
2. When `merge_predictions([])` is called programmatically (e.g. from
   a test or a caller that filters its own list before invoking
   merge), the loop never runs and `directory` is never bound, so the
   warning itself raises `UnboundLocalError` instead of returning
   cleanly. (The CLI is safe via `nargs="+"`, but the function is
   exported and callable directly.)

## Why the fix is correct

`directories` is the function's input parameter; it always exists and
always lists exactly the paths that were searched, including the empty
case. Formatting it produces a message that is both correct for the
multi-directory case and safe for the empty case, with no behavioural
change beyond the warning text.

## Change

`sweagent/run/merge_predictions.py`: format `directories` instead of
`directory` in the "No predictions found" warning. One-line change.