### PR TITLE
fix(agent): capture DeepSeek reasoning_content in trajectory (fixes #1333)

### DIFF
--- a/sweagent/agent/agents.py
+++ b/sweagent/agent/agents.py
@@ -723,6 +723,7 @@ class DefaultAgent(AbstractAgent):
                 "tool_calls": step.tool_calls,
                 "message_type": "action",
                 "thinking_blocks": step.thinking_blocks,
+                "reasoning_content": step.reasoning_content,
             },
         )
 
@@ -1044,6 +1045,7 @@ class DefaultAgent(AbstractAgent):
             # todo: Can't I override the parser in __init__?
             step.thought, step.action = self.tools.parse_actions(output)
             step.thinking_blocks = output.get("thinking_blocks", [])
+            step.reasoning_content = output.get("reasoning_content")
             if output.get("tool_calls") is not None:
                 step.tool_call_ids = [call["id"] for call in output["tool_calls"]]
                 step.tool_calls = output["tool_calls"]

--- a/sweagent/agent/hooks/abstract.py
+++ b/sweagent/agent/hooks/abstract.py
@@ -117,6 +117,7 @@ class CombinedAgentHook(AbstractAgentHook):
         tool_calls: list[dict[str, str]] | None = None,
         tool_call_ids: list[str] | None = None,
         thinking_blocks: list[dict[str, str]] | None = None,
+        reasoning_content: str | None = None,
     ):
         for hook in self.hooks:
             hook.on_query_message_added(

--- a/sweagent/agent/models.py
+++ b/sweagent/agent/models.py
@@ -776,6 +776,14 @@ class LiteLLMModel(AbstractModel):
                 and response.choices[i].message.thinking_blocks  # type: ignore
             ):
                 output_dict["thinking_blocks"] = response.choices[i].message.thinking_blocks  # type: ignore
+            # DeepSeek-style reasoning models expose chain-of-thought via reasoning_content.
+            # Capture it so it is preserved in the trajectory and history. We do not echo it
+            # back to the model: the DeepSeek API rejects reasoning_content sent as input.
+            if (
+                hasattr(response.choices[i].message, "reasoning_content")  # type: ignore
+                and response.choices[i].message.reasoning_content  # type: ignore
+            ):
+                output_dict["reasoning_content"] = response.choices[i].message.reasoning_content  # type: ignore
             outputs.append(output_dict)
         self._update_stats(input_tokens=input_tokens, output_tokens=output_tokens, cost=cost)
         return outputs

--- a/sweagent/types.py
+++ b/sweagent/types.py
@@ -26,6 +26,7 @@ class StepOutput(BaseModel):
     tool_calls: list[dict[str, Any]] | None = None
     tool_call_ids: list[str] | None = None
     thinking_blocks: list[dict[str, Any]] | None = None
+    reasoning_content: str | None = None
 
     """State of the environment at the end of the step"""
     extra_info: dict[str, Any] = {}
@@ -70,6 +71,7 @@ class HistoryItem(_HistoryItem, total=False):
     tags: list[str]
     cache_control: dict[str, Any] | None
     thinking_blocks: list[dict[str, Any]] | None
+    reasoning_content: str | None
 
     """HistoryProcessors can add these tags to enable special processing"""
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -104,3 +104,75 @@ def test_user_agent_header_with_other_extra_headers():
         extra_headers = call_kwargs.kwargs.get("extra_headers", {})
         assert extra_headers["User-Agent"] == f"swe-agent/{__version__}"
         assert extra_headers["X-Custom"] == "value"
+
+
+def _make_reasoning_mock_response(
+    content: str = "final answer",
+    reasoning_content: str | None = None,
+    has_reasoning_attr: bool = True,
+) -> MagicMock:
+    """Mock response with controlled reasoning_content / thinking_blocks attribute presence."""
+    choice = MagicMock()
+    choice.message.content = content
+    choice.message.tool_calls = None
+    # MagicMock auto-creates attributes on access; explicitly drop the ones we want absent
+    # so the production hasattr() checks in _single_query exercise both branches.
+    del choice.message.thinking_blocks
+    if has_reasoning_attr:
+        choice.message.reasoning_content = reasoning_content
+    else:
+        del choice.message.reasoning_content
+    response = MagicMock()
+    response.choices = [choice]
+    response.usage.prompt_tokens = 10
+    response.usage.completion_tokens = 5
+    return response
+
+
+def _make_reasoning_model():
+    return get_model(
+        GenericAPIModelConfig(
+            name="deepseek/deepseek-reasoner",
+            api_key=SecretStr("dummy_key"),
+            top_p=None,
+            per_instance_cost_limit=0,
+            total_cost_limit=0,
+        ),
+        ToolConfig(parse_function=Identity()),
+    )
+
+
+def test_reasoning_content_captured():
+    """reasoning_content from DeepSeek-style responses is preserved in the output dict."""
+    model = _make_reasoning_model()
+    mock_response = _make_reasoning_mock_response(
+        content="42",
+        reasoning_content="The user asked about the meaning of life. I considered several angles.",
+    )
+    with patch("litellm.completion", return_value=mock_response):
+        result = model.query(History([{"role": "user", "content": "What is the meaning of life?"}]))
+        assert isinstance(result, dict)
+        assert result["message"] == "42"
+        assert result["reasoning_content"] == "The user asked about the meaning of life. I considered several angles."
+
+
+def test_reasoning_content_absent_when_attribute_missing():
+    """Models that do not expose reasoning_content (e.g. GPT-4o) leave the key out of the output."""
+    model = _make_reasoning_model()
+    mock_response = _make_reasoning_mock_response(content="hello", has_reasoning_attr=False)
+    with patch("litellm.completion", return_value=mock_response):
+        result = model.query(History([{"role": "user", "content": "hi"}]))
+        assert isinstance(result, dict)
+        assert result["message"] == "hello"
+        assert "reasoning_content" not in result
+
+
+def test_reasoning_content_absent_when_empty():
+    """An empty/None reasoning_content is not propagated, mirroring the thinking_blocks guard."""
+    model = _make_reasoning_model()
+    mock_response = _make_reasoning_mock_response(content="hello", reasoning_content=None)
+    with patch("litellm.completion", return_value=mock_response):
+        result = model.query(History([{"role": "user", "content": "hi"}]))
+        assert isinstance(result, dict)
+        assert result["message"] == "hello"
+        assert "reasoning_content" not in result


### PR DESCRIPTION
Fixes #1333.

DeepSeek reasoning models (DeepSeek-R1, V3.2-Exp) return chain-of-thought via `message.reasoning_content` (separate from Anthropic-style `thinking_blocks`). The `_single_query` path in `LiteLLMModel` builds `output_dict` field by field and only mapped `content`, `tool_calls`, and `thinking_blocks`, so `reasoning_content` was silently dropped. Downstream features that depend on history recording (the issue reporter cites "integrate think") therefore could not see the model's reasoning.

## Root cause

`sweagent/agent/models.py` `_single_query` constructs `output_dict` explicitly. There was no branch for `reasoning_content`, even though `litellm` exposes it on the message object for OpenAI-compatible reasoning models.

## Fix

Treat `reasoning_content` exactly like `thinking_blocks`: capture it in `_single_query` if present, thread it through `StepOutput`, and store it on the `HistoryItem`. The change is purely additive and follows the existing pattern.

- `sweagent/agent/models.py`: capture `reasoning_content` in `_single_query` (mirrors the `thinking_blocks` block immediately above).
- `sweagent/agent/agents.py`: set `step.reasoning_content` from the model output and include it in the appended history item.
- `sweagent/types.py`: add the optional field to `StepOutput` and `HistoryItem`.
- `sweagent/agent/hooks/abstract.py`: accept `reasoning_content` on `CombinedAgentHook.on_query_message_added` so `_append_history(**item)` does not raise (matches how `thinking_blocks` is already handled there).

## Why not echo it back to the model

`reasoning_content` is intentionally not added to outgoing messages in `_history_to_messages`. Per the [DeepSeek reasoning-model docs](https://api-docs.deepseek.com/guides/reasoning_model), passing `reasoning_content` as input returns HTTP 400. The previously closed PR #1357 took a broader approach (`to_dict()` over the whole raw message) and was set aside after the maintainer asked for cross-model testing. This PR avoids that risk: behavior for every existing model is unchanged.

## Testing

`tests/test_models.py` adds three cases that mock `litellm.completion` and exercise `_single_query` end to end through `model.query`:

- `test_reasoning_content_captured` — message exposes `reasoning_content`; assert it appears in the returned dict.
- `test_reasoning_content_absent_when_attribute_missing` — message has no such attribute (for example GPT-4o); assert the key is omitted.
- `test_reasoning_content_absent_when_empty` — attribute is present but `None`; assert the truthiness guard skips it (mirrors the `thinking_blocks` guard).

Verified locally with `ruff check`, `ruff format --check`, and the pytest subset relevant to this change:

```
pytest tests/test_models.py tests/test_agent.py tests/test_history_processors.py tests/test_run_hooks.py -q
# 29 passed, 2 xfailed
```

Remaining failures in the full suite (`test_env.py`, `test_run_single.py`, etc.) require Docker and an authenticated `GITHUB_TOKEN` and reproduce on `main`; they are unaffected by this PR.

## Scope boundary

This PR captures `reasoning_content` in trajectory and history only. It does not change how messages are sent to the model, does not touch any provider-specific routing, and does not alter `thinking_blocks` behavior.