### PR TITLE
fix(parsing): define values when tool_call arguments is already a dict in FunctionCallingParser

### DIFF
--- a/sweagent/tools/parsing.py
+++ b/sweagent/tools/parsing.py
@@ -406,6 +406,8 @@ class FunctionCallingParser(AbstractParseFunction, BaseModel):
             except json.JSONDecodeError:
                 msg = "Tool call arguments are not valid JSON."
                 raise FunctionCallingFormatError(msg, "invalid_json")
+        else:
+            values = tool_call["function"]["arguments"]
         required_args = {arg.name for arg in command.arguments if arg.required}
         missing_args = required_args - values.keys()
         if missing_args:


### PR DESCRIPTION
## Bug

\`FunctionCallingParser._parse_tool_call\` (\`sweagent/tools/parsing.py\`) crashes with \`NameError: name 'values' is not defined\` whenever \`tool_call[\"function\"][\"arguments\"]\` is delivered as a \`dict\` rather than a JSON string.

## Root cause

\`\`\`python
if not isinstance(tool_call[\"function\"][\"arguments\"], dict):
    try:
        values = json.loads(tool_call[\"function\"][\"arguments\"])
    except json.JSONDecodeError:
        msg = \"Tool call arguments are not valid JSON.\"
        raise FunctionCallingFormatError(msg, \"invalid_json\")
required_args = {arg.name for arg in command.arguments if arg.required}
missing_args = required_args - values.keys()
\`\`\`

\`values\` is only bound inside the \`not isinstance(..., dict)\` branch. The branch guard explicitly anticipates the dict case — that's the *only* reason to test \`isinstance(..., dict)\` at all — but no \`else\` was written, so when arguments come in as a dict (which several litellm provider adapters and the anthropic-style tool-call shape do), control falls through to \`values.keys()\` with \`values\` undefined.

## Fix

Add an \`else\` that binds \`values\` to the existing dict. Two-line addition, no behavior change for the JSON-string path.