### PR TITLE
Fix SimpleBatchInstance repo names containing github

### DIFF
--- a/sweagent/run/batch_instances.py
+++ b/sweagent/run/batch_instances.py
@@ -23,7 +23,7 @@ from sweagent.agent.problem_statement import (
 from sweagent.environment.repo import GithubRepoConfig, LocalRepoConfig, PreExistingRepoConfig, SWESmithRepoConfig
 from sweagent.environment.swe_env import EnvironmentConfig
 from sweagent.utils.files import load_file
-from sweagent.utils.github import _is_repo_private
+from sweagent.utils.github import _is_github_repo_url, _is_repo_private
 from sweagent.utils.log import get_logger
 
 logger = get_logger("swea-config", emoji="🔧")
@@ -98,7 +98,7 @@ class SimpleBatchInstance(BaseModel):
     repo_name: str = ""
     """Specifies the repository to use. If empty, no repository is used.
     If the string does not contain a slash, it is interpreted as an already existing repository at the root
-    of the docker container. If it contains the word "github", it is interpreted as a github repository.
+    of the docker container. If it is a GitHub URL, it is interpreted as a github repository.
     Else, it is interpreted as a local repository.
     """
     base_commit: str = "HEAD"
@@ -130,7 +130,7 @@ class SimpleBatchInstance(BaseModel):
 
         if not self.repo_name:
             repo = None
-        elif "github" in self.repo_name:
+        elif _is_github_repo_url(self.repo_name):
             repo = GithubRepoConfig(github_url=self.repo_name, base_commit=self.base_commit)
         elif "/" not in self.repo_name:
             repo = PreExistingRepoConfig(repo_name=self.repo_name, base_commit=self.base_commit)

--- a/tests/test_batch_instance.py
+++ b/tests/test_batch_instance.py
@@ -4,7 +4,7 @@ import pytest
 from swerex.deployment.config import DockerDeploymentConfig
 
 from sweagent.agent.problem_statement import TextProblemStatement
-from sweagent.environment.repo import PreExistingRepoConfig
+from sweagent.environment.repo import GithubRepoConfig, PreExistingRepoConfig
 from sweagent.run.batch_instances import BatchInstance, SimpleBatchInstance, SWEBenchInstances, _slice_spec_to_slice
 
 
@@ -20,6 +20,31 @@ def test_simple_batch_from_swe_bench_to_full_batch_instance(test_data_sources_pa
     assert isinstance(instance.problem_statement, TextProblemStatement)
     assert instance.problem_statement.text == sb_instance["problem_statement"]
     assert instance.problem_statement.id == "pydicom__pydicom-1458"
+
+
+@pytest.mark.parametrize("repo_name", ["go-github", "github", "github-action-build-chain"])
+def test_simple_batch_treats_repo_names_containing_github_as_existing_repos(repo_name):
+    instance = SimpleBatchInstance(
+        image_name="python:3.11",
+        problem_statement="Fix the bug",
+        instance_id="repo-name-with-github",
+        repo_name=repo_name,
+    ).to_full_batch_instance(DockerDeploymentConfig(image="python:3.11"))
+
+    assert isinstance(instance.env.repo, PreExistingRepoConfig)
+    assert instance.env.repo.repo_name == repo_name
+
+
+def test_simple_batch_treats_github_urls_as_github_repos():
+    instance = SimpleBatchInstance(
+        image_name="python:3.11",
+        problem_statement="Fix the bug",
+        instance_id="github-url",
+        repo_name="https://github.com/SWE-agent/test-repo",
+    ).to_full_batch_instance(DockerDeploymentConfig(image="python:3.11"))
+
+    assert isinstance(instance.env.repo, GithubRepoConfig)
+    assert instance.env.repo.github_url == "https://github.com/SWE-agent/test-repo"
 
 
 def test_slice_spec_to_slice():


### PR DESCRIPTION
#### Reference Issues/PRs

None.

#### What does this implement/fix? Explain your changes.

`SimpleBatchInstance.to_full_batch_instance` previously treated any `repo_name` containing the substring `github` as a GitHub repository. That misclassified pre-existing repositories in benchmark containers such as `go-github`, `github`, and `github-action-build-chain`, then failed when those plain directory names were parsed as GitHub URLs.

This changes the detection to use the existing GitHub repo URL matcher, so only actual GitHub URLs use `GithubRepoConfig`; plain container repo names continue to use `PreExistingRepoConfig`. It also updates the docstring and adds regression coverage for repo names containing `github` and for a real GitHub URL.

Checks run locally:

- `python -m py_compile sweagent/run/batch_instances.py tests/test_batch_instance.py`
- `ruff check sweagent/run/batch_instances.py tests/test_batch_instance.py`
- A lightweight assertion script covering the new `PreExistingRepoConfig` and `GithubRepoConfig` paths.

Note: `uv run --extra dev pytest tests/test_batch_instance.py -q` could not complete locally because dependency resolution was blocked by repeated TLS handshake failures against the configured PyPI mirror while fetching `setuptools`.