### PR TITLE
Fix line offset bug in insert command

### DIFF
--- a/tools/windowed_edit_replace/bin/insert
+++ b/tools/windowed_edit_replace/bin/insert
@@ -46,7 +46,7 @@ def main(text: str, line: Union[int, None] = None):
         exit(1)
 
     pre_edit_lint = flake8(wf.path)
-    insert_info = wf.insert(text, line=line - 1 if line is not None else None)
+    insert_info = wf.insert(text, line=line if line is not None else None)
     post_edit_lint = flake8(wf.path)
 
     # Try to filter out pre-existing errors


### PR DESCRIPTION
### Bug
When executing `insert {content} {line}` (intended to insert the text as new lines *after* the specified `line`), the content is instead inserted before that line (i.e. between `line - 1` and `line`).

### Root Cause
In `tools/windowed_edit_replace/bin/insert`, the CLI script incorrectly subtracts 1 from the specified line number (`line - 1`) before passing it to `wf.insert()`. Inside `windowed_file.py`, `lines.insert(line, text)` is called, which inserts *before* the 0-indexed list index `line`. Since line `k` is at index `k - 1`, putting the element at index `k` naturally places it *after* line `k`. Thus, the correct 0-indexed insertion index is exactly `line`, and subtracting 1 incorrectly placed it before that line.

### Why Fix is Correct
This change removes the `- 1` offset subtraction in the CLI script, passing `line` directly to `wf.insert()`. This ensures that inserting after line `k` places the new content precisely at index `k` (directly after line `k`), matching the documented behavior and fixing the offset misalignment.