### PR TITLE
Fix: tools install fails with 127 because source is not found in /bin/sh

### DIFF
--- a/sweagent/tools/tools.py
+++ b/sweagent/tools/tools.py
@@ -300,7 +300,7 @@ class ToolHandler:
                 f"chmod +x /root/tools/{bundle.path.name}/bin/*",
             ]
             if (bundle.path / "install.sh").exists():
-                cmds.append(f"cd /root/tools/{bundle.path.name} && source install.sh")
+                cmds.append(f"cd /root/tools/{bundle.path.name} && . install.sh")
             cmds.append(f"chmod +x /root/tools/{bundle.path.name}/bin/*")
             env.communicate(
                 " && ".join(cmds),


### PR DESCRIPTION
Bug: When installing tools, SWE-agent attempts to run `source install.sh` via `env.communicate`. If the container environment defaults to `/bin/sh` (like dash on Debian/Ubuntu), `source` is not a built-in command, causing the installation to fail with exit code 127. Root cause: `source` is a bash extension and does not exist in standard POSIX sh. Why fix is correct: Using `.` instead of `source` is POSIX-compliant and ensures compatibility across different default shells.