### PR TITLE
Fix FunctionCallingParser handling of dict arguments and array types passed as strings

### DIFF
--- a/sweagent/tools/parsing.py
+++ b/sweagent/tools/parsing.py
@@ -427,9 +427,11 @@ class FunctionCallingParser(AbstractParseFunction, BaseModel):
                 if isinstance(values[arg.name], str):
                     try:
                         import ast
+
                         values[arg.name] = ast.literal_eval(values[arg.name])
                     except Exception:
                         pass
+
         def get_quoted_arg(value: Any) -> str:
             if isinstance(value, str):
                 return quote(value) if _should_quote(value, command) else value

--- a/sweagent/tools/parsing.py
+++ b/sweagent/tools/parsing.py
@@ -406,6 +406,8 @@ class FunctionCallingParser(AbstractParseFunction, BaseModel):
             except json.JSONDecodeError:
                 msg = "Tool call arguments are not valid JSON."
                 raise FunctionCallingFormatError(msg, "invalid_json")
+        else:
+            values = tool_call["function"]["arguments"]
         required_args = {arg.name for arg in command.arguments if arg.required}
         missing_args = required_args - values.keys()
         if missing_args:
@@ -420,6 +422,14 @@ class FunctionCallingParser(AbstractParseFunction, BaseModel):
             msg = f"Unexpected argument(s): {', '.join(extra_args)}"
             raise FunctionCallingFormatError(msg, "unexpected_arg")
 
+        for arg in command.arguments:
+            if getattr(arg, "type", None) == "array" and arg.name in values:
+                if isinstance(values[arg.name], str):
+                    try:
+                        import ast
+                        values[arg.name] = ast.literal_eval(values[arg.name])
+                    except Exception:
+                        pass
         def get_quoted_arg(value: Any) -> str:
             if isinstance(value, str):
                 return quote(value) if _should_quote(value, command) else value


### PR DESCRIPTION
Bug: 1) `FunctionCallingParser` raised `UnboundLocalError` when `tool_call['function']['arguments']` was already a dictionary, because `values` was unassigned. 2) Array-type arguments passed as strings (e.g., `'(1, 50)'` or `'[1, 50]'`) were iterated as strings by Jinja `join(' ')`, resulting in spaced outputs like `[ 1 , 5 0 ]` (Fixes #1182).
Root Cause: 1) Missing `else` clause when checking if arguments is not a dictionary. 2) No mechanism to parse stringified arrays in `FunctionCallingParser` unlike `XMLFunctionCallingParser`.
Why fix is correct: 1) Adds the missing `else: values = ...` clause. 2) Safely parses array arguments using `ast.literal_eval` if they are provided as strings.