### PR TITLE
Fix FunctionCallingParser tuple/list arguments parsed as string

### DIFF
--- a/sweagent/tools/parsing.py
+++ b/sweagent/tools/parsing.py
@@ -423,13 +423,15 @@ class FunctionCallingParser(AbstractParseFunction, BaseModel):
             raise FunctionCallingFormatError(msg, "unexpected_arg")
 
         for arg in command.arguments:
-            if getattr(arg, "type", None) == "array" and arg.name in values:
+            if arg.name in values:
                 if isinstance(values[arg.name], str):
-                    try:
-                        import ast
-                        values[arg.name] = ast.literal_eval(values[arg.name])
-                    except Exception:
-                        pass
+                    val_str = values[arg.name].strip()
+                    if getattr(arg, "type", None) == "array" or val_str.startswith("[") or val_str.startswith("("):
+                        try:
+                            import ast
+                            values[arg.name] = ast.literal_eval(val_str)
+                        except Exception:
+                            pass
         def get_quoted_arg(value: Any) -> str:
             if isinstance(value, str):
                 return quote(value) if _should_quote(value, command) else value

--- a/sweagent/tools/parsing.py
+++ b/sweagent/tools/parsing.py
@@ -429,9 +429,11 @@ class FunctionCallingParser(AbstractParseFunction, BaseModel):
                     if getattr(arg, "type", None) == "array" or val_str.startswith("[") or val_str.startswith("("):
                         try:
                             import ast
+
                             values[arg.name] = ast.literal_eval(val_str)
                         except Exception:
                             pass
+
         def get_quoted_arg(value: Any) -> str:
             if isinstance(value, str):
                 return quote(value) if _should_quote(value, command) else value

--- a/sweagent/tools/parsing.py
+++ b/sweagent/tools/parsing.py
@@ -406,6 +406,8 @@ class FunctionCallingParser(AbstractParseFunction, BaseModel):
             except json.JSONDecodeError:
                 msg = "Tool call arguments are not valid JSON."
                 raise FunctionCallingFormatError(msg, "invalid_json")
+        else:
+            values = tool_call["function"]["arguments"]
         required_args = {arg.name for arg in command.arguments if arg.required}
         missing_args = required_args - values.keys()
         if missing_args:
@@ -420,6 +422,14 @@ class FunctionCallingParser(AbstractParseFunction, BaseModel):
             msg = f"Unexpected argument(s): {', '.join(extra_args)}"
             raise FunctionCallingFormatError(msg, "unexpected_arg")
 
+        for arg in command.arguments:
+            if getattr(arg, "type", None) == "array" and arg.name in values:
+                if isinstance(values[arg.name], str):
+                    try:
+                        import ast
+                        values[arg.name] = ast.literal_eval(values[arg.name])
+                    except Exception:
+                        pass
         def get_quoted_arg(value: Any) -> str:
             if isinstance(value, str):
                 return quote(value) if _should_quote(value, command) else value


### PR DESCRIPTION
Bug: Tuple of ints gets turned into string when passed to FunctionCallingParser, causing argument parsing failures (e.g. invalid int value: '['). Root cause: If the LLM returns the argument as a string representation of a list or tuple, the isinstance(str) block didn't evaluate it properly because it strictly checked for type='array' which failed or wasn't flexible enough for tuples. Why fix is correct: Checking if the string starts with '[' or '(' ensures that stringified lists and tuples are correctly evaluated by ast.literal_eval before being passed to Jinja.