### PR TITLE
fix: replace expired Slack invite link

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,5 +4,5 @@ contact_links:
     url: https://github.com/SWE-agent/SWE-agent/issues/new
     about: None of the above? Open a blank issue
   - name: Slack server
-    url: https://join.slack.com/t/swe-bench/shared_invite/zt-36pj9bu5s-o3_yXPZbaH2wVnxnss1EkQ
+    url: https://swe-bench.slack.com
     about: Open ended discussions

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <p align="center">
 <a href="https://swe-agent.com/latest/"><img src="https://img.shields.io/badge/Docs-green?style=for-the-badge&logo=materialformkdocs&logoColor=white" alt="Docs"></a>
-<a href="https://join.slack.com/t/swe-bench/shared_invite/zt-36pj9bu5s-o3_yXPZbaH2wVnxnss1EkQ"><img src="https://img.shields.io/badge/Slack-4A154B?style=for-the-badge&logo=slack&logoColor=white" alt="Slack"></a>
+<a href="https://swe-bench.slack.com"><img src="https://img.shields.io/badge/Slack-4A154B?style=for-the-badge&logo=slack&logoColor=white" alt="Slack"></a>
 <a href="https://arxiv.org/abs/2405.15793"><img src="https://img.shields.io/badge/arxiv-2405.15793-red?style=for-the-badge&logo=arxiv&logoColor=white&labelColor=black" alt="arxiv 2405.15793"></a>
 </p>
 

--- a/docs/_footer.md
+++ b/docs/_footer.md
@@ -9,7 +9,7 @@
     </div>
   </a>
 
-  <a href="https://join.slack.com/t/swe-bench/shared_invite/zt-36pj9bu5s-o3_yXPZbaH2wVnxnss1EkQ" class="nav-card-link">
+  <a href="https://swe-bench.slack.com" class="nav-card-link">
     <div class="nav-card">
       <div class="nav-card-header">
         <span class="material-icons nav-card-icon">help</span>


### PR DESCRIPTION
The `shared_invite` link in the README badge, docs footer, and issue template config expired (Slack invite links die after 30 days). Replaced all three with the workspace URL which doesn't expire.

Fixes #1383