### PR TITLE
security: fix path traversal in inspector server and command injection via repo_name

### DIFF
--- a/sweagent/environment/repo.py
+++ b/sweagent/environment/repo.py
@@ -112,7 +112,9 @@ class LocalRepoConfig(BaseModel):
             deployment.runtime.upload(UploadRequest(source_path=str(self.path), target_path=f"/{self.repo_name}"))
         )
         r = asyncio.run(
-            deployment.runtime.execute(Command(command=f"chown -R root:root /{shlex.quote(self.repo_name)}", shell=True))
+            deployment.runtime.execute(
+                Command(command=f"chown -R root:root /{shlex.quote(self.repo_name)}", shell=True)
+            )
         )
         if r.exit_code != 0:
             msg = f"Failed to change permissions on copied repository (exit code: {r.exit_code}, stdout: {r.stdout}, stderr: {r.stderr})"

--- a/sweagent/environment/repo.py
+++ b/sweagent/environment/repo.py
@@ -112,7 +112,7 @@ class LocalRepoConfig(BaseModel):
             deployment.runtime.upload(UploadRequest(source_path=str(self.path), target_path=f"/{self.repo_name}"))
         )
         r = asyncio.run(
-            deployment.runtime.execute(Command(command=f"chown -R root:root /{self.repo_name}", shell=True))
+            deployment.runtime.execute(Command(command=f"chown -R root:root /{shlex.quote(self.repo_name)}", shell=True))
         )
         if r.exit_code != 0:
             msg = f"Failed to change permissions on copied repository (exit code: {r.exit_code}, stdout: {r.stdout}, stderr: {r.stderr})"
@@ -170,8 +170,8 @@ class GithubRepoConfig(BaseModel):
                 Command(
                     command=" && ".join(
                         (
-                            f"mkdir /{self.repo_name}",
-                            f"cd /{self.repo_name}",
+                            f"mkdir /{shlex.quote(self.repo_name)}",
+                            f"cd /{shlex.quote(self.repo_name)}",
                             "git init",
                             f"git remote add origin {shlex.quote(url)}",
                             f"git fetch --depth 1 origin {shlex.quote(base_commit)}",

--- a/sweagent/environment/swe_env.py
+++ b/sweagent/environment/swe_env.py
@@ -153,7 +153,7 @@ class SWEEnv:
             # todo: Currently has swe-ft specific change: The original repo.copy isn't called, because the repo is already
             # present. However, reset --hard <BRANCH> also doesn't work. So modified it here to do a checkout instead.
             startup_commands = [
-                f"cd /{self.repo.repo_name}",
+                f"cd /{shlex.quote(self.repo.repo_name)}",
                 "export ROOT=$(pwd -P)",
                 *self.repo.get_reset_commands(),
             ]

--- a/sweagent/inspector/server.py
+++ b/sweagent/inspector/server.py
@@ -238,9 +238,13 @@ class Handler(http.server.SimpleHTTPRequestHandler):
         self.wfile.write(json.dumps({"directory": self.traj_dir}).encode())
 
     def serve_file_content(self, file_path):
+        safe_path = (Path(self.traj_dir) / file_path).resolve()
+        if not str(safe_path).startswith(str(Path(self.traj_dir).resolve())):
+            self.send_error(403, "Access denied")
+            return
         try:
             content = load_content(
-                Path(self.traj_dir) / file_path,
+                safe_path,
                 self.gold_patches,
                 self.test_patches,
             )

--- a/tests/inspector/test_server.py
+++ b/tests/inspector/test_server.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import io
+import json
+import socket
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from sweagent.inspector.server import Handler
+
+
+class MockRequest:
+    def __init__(self, data: bytes = b""):
+        self.rfile = io.BytesIO(data)
+        self.wfile = io.BytesIO()
+        self.client_address = ("127.0.0.1", 12345)
+
+
+def make_handler(traj_dir: Path, path: str) -> Handler:
+    request = MockRequest()
+    server = MagicMock()
+    handler = Handler(request, request.client_address, server, directory=str(traj_dir))
+    handler.path = path
+    handler.request_version = "HTTP/1.1"
+    handler.command = "GET"
+    handler.headers = {}
+    return handler
+
+
+def test_trajectory_path_traversal_blocked(tmp_path: Path):
+    traj_dir = tmp_path / "trajectories"
+    traj_dir.mkdir()
+    secret_dir = tmp_path / "secret"
+    secret_dir.mkdir()
+    secret_file = secret_dir / "secret.txt"
+    secret_file.write_text("secret data")
+
+    handler = make_handler(traj_dir, "/trajectory/../secret/secret.txt")
+    handler.do_GET()
+
+    response = handler.request.wfile.getvalue()
+    assert b"403" in response or b"Access denied" in response
+
+
+def test_trajectory_valid_file_allowed(tmp_path: Path):
+    traj_dir = tmp_path / "trajectories"
+    traj_dir.mkdir()
+    traj_file = traj_dir / "test.traj"
+    traj_file.write_text(json.dumps({"trajectory": [], "history": []}))
+
+    handler = make_handler(traj_dir, "/trajectory/test.traj")
+    handler.do_GET()
+
+    response = handler.request.wfile.getvalue()
+    assert b"403" not in response
+    assert b"Access denied" not in response

--- a/tests/inspector/test_server.py
+++ b/tests/inspector/test_server.py
@@ -2,11 +2,8 @@ from __future__ import annotations
 
 import io
 import json
-import socket
 from pathlib import Path
 from unittest.mock import MagicMock
-
-import pytest
 
 from sweagent.inspector.server import Handler
 


### PR DESCRIPTION
This PR fixes two security vulnerabilities:

### 1. Path Traversal in Inspector HTTP Server
**File:** sweagent/inspector/server.py
**CWE:** CWE-22 (Path Traversal)

The serve_file_content() method resolved user-provided ile_path without validating it stayed within 	raj_dir. An attacker could request files outside the intended directory using ../ sequences.

**Fix:** Added path traversal validation using Path.resolve() and a prefix check against 	raj_dir.

### 2. Command Injection via 
epo_name
**Files:** sweagent/environment/repo.py, sweagent/environment/swe_env.py
**CWE:** CWE-78 (OS Command Injection)


epo_name was interpolated directly into shell commands without escaping. A malicious repo name like evil; rm -rf / would execute arbitrary commands.

**Fix:** Added shlex.quote() around all 
epo_name interpolations in shell commands.
