### PR TITLE
Fix function calling command parsing for list/tuple of ints

### DIFF
--- a/sweagent/tools/parsing.py
+++ b/sweagent/tools/parsing.py
@@ -426,6 +426,8 @@ class FunctionCallingParser(AbstractParseFunction, BaseModel):
             # See https://github.com/SWE-agent/SWE-agent/issues/1159
             if value is None:
                 return ""
+            if isinstance(value, (list, tuple)):
+                return " ".join(str(v) for v in value)
             return value
 
         formatted_args = {


### PR DESCRIPTION
Bug: Tuple of ints gets turned into string representation like `[ 1, 50 ]` instead of space-separated strings when parsing function calling commands.
Root cause: The `FunctionCallingParser` passes lists directly to the jinja template which renders it as its string representation, causing argparse to crash when parsing the command.
Why fix is correct: Added logic in `get_quoted_arg` to space-join lists and tuples, ensuring argparse can parse them cleanly.