### PR TITLE
fix: insert after target line instead of before it

### DIFF
--- a/tools/windowed_edit_replace/bin/insert
+++ b/tools/windowed_edit_replace/bin/insert
@@ -46,7 +46,7 @@ def main(text: str, line: Union[int, None] = None):
         exit(1)
 
     pre_edit_lint = flake8(wf.path)
-    insert_info = wf.insert(text, line=line - 1 if line is not None else None)
+    insert_info = wf.insert(text, line=line if line is not None else None)
     post_edit_lint = flake8(wf.path)
 
     # Try to filter out pre-existing errors


### PR DESCRIPTION
Fixes #1331

## Bug
The `insert` action inserts text before the requested line instead of after it (e.g. `insert ... 5` puts content after line 4).

## Root cause
`tools/windowed_edit_replace/bin/insert` passes `line - 1` into `WindowedFile.insert()`, shifting the insertion point one line too early.

## Why this fix is correct
`WindowedFile.insert()` already uses a 0-based index where `lines.insert(line, text)` places content before index `line`. For a 1-indexed CLI line number N, pass `line=N` so content is inserted after line N.

Made with [Cursor](https://cursor.com)