### PR TITLE
fix: space-join list/tuple args in FunctionCallingParser

### DIFF
--- a/sweagent/tools/parsing.py
+++ b/sweagent/tools/parsing.py
@@ -426,6 +426,8 @@ class FunctionCallingParser(AbstractParseFunction, BaseModel):
             # See https://github.com/SWE-agent/SWE-agent/issues/1159
             if value is None:
                 return ""
+            if isinstance(value, (list, tuple)):
+                return " ".join(str(v) for v in value)
             return value
 
         formatted_args = {


### PR DESCRIPTION
Fixes #1182

## Bug
Function-calling tool args like `view_range: [1, 100]` are rendered as the string `[1, 100]`, so argparse sees a single invalid token instead of two integers.

## Root cause
`FunctionCallingParser.get_quoted_arg()` returns list/tuple values unchanged; Jinja renders them as Python repr strings in the command template.

## Why this fix is correct
Space-join list/tuple elements (matching the XML parser behavior for `view_range`) produces `1 100`, which argparse accepts for multi-value arguments like `--view_range`.

Made with [Cursor](https://cursor.com)