### PR TITLE
fix: stop printing full patch in submit to avoid pexpect timeouts

### DIFF
--- a/tools/submit/bin/submit
+++ b/tools/submit/bin/submit
@@ -10,8 +10,6 @@ main() {
     git add -A
     git diff --cached > /root/model.patch
     echo "<<SWE_AGENT_SUBMISSION>>"
-    cat /root/model.patch
-    echo "<<SWE_AGENT_SUBMISSION>>"
 }
 
 main "$@"


### PR DESCRIPTION
## Summary
Fixes #1269.

`submit` can hang for minutes when `git diff --cached` is very large, because the shell prints the entire patch to stdout before pexpect sees the prompt marker again.

## Root cause
The submit tool ran `cat /root/model.patch` after writing the patch. Large diffs flood the runtime output buffer and cause pexpect to time out waiting for the shell prompt, even though SWE-agent already reads the submission from `/root/model.patch`.

## Fix
Keep writing the patch to `/root/model.patch` and emit only the submission marker. `handle_submission()` loads the patch from the file, so stdout no longer needs the full diff contents.

## Test plan
- [ ] Run `submit` on a repo with a large staged diff; command should return promptly
- [ ] Confirm submitted trajectories still contain the full patch from `/root/model.patch`


Made with [Cursor](https://cursor.com)