### PR TITLE
harden(tools): block interactive commands in wrapped/compound forms

### DIFF
--- a/sweagent/tools/tools.py
+++ b/sweagent/tools/tools.py
@@ -9,6 +9,7 @@ import asyncio
 import json
 import os
 import re
+import shlex
 from functools import cached_property
 from pathlib import Path
 from typing import Any
@@ -224,6 +225,108 @@ class ToolConfig(BaseModel):
                 break
 
 
+# Shell control operators that separate one command invocation from another in a
+# compound command line. Used to make the blocklist see every individual command,
+# not just the first token of the whole line.
+_COMMAND_SEPARATOR_TOKENS = frozenset({";", "&", "&&", "|", "||", "\n", "(", ")", "{", "}"})
+# Tokens produced by quote-aware tokenization of ``$(...)`` that are not real commands.
+_SUBSTITUTION_NOISE_TOKENS = frozenset({"$", "(", ")"})
+# Inner commands of command substitutions ``$(...)`` and back-ticked ``...``.
+_COMMAND_SUBSTITUTION_RE = re.compile(r"\$\((.*?)\)|`(.*?)`", re.DOTALL)
+# Wrapper programs that run another command passed as their (trailing) argument.
+# e.g. ``env vim``, ``sudo nano`` -- the wrapped command must also be checked.
+_COMMAND_WRAPPERS = frozenset(
+    {"env", "command", "builtin", "exec", "nohup", "sudo", "time", "nice", "stdbuf", "setsid"}
+)
+_ENV_ASSIGNMENT_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
+
+
+def _iter_command_invocations(action: str) -> list[str]:
+    """Break a (possibly compound) command line into its individual command invocations.
+
+    Splits on shell control operators (``;`` ``&&`` ``||`` ``|`` ``&`` newlines) and
+    additionally extracts the inner commands of command substitutions (``$(...)`` and
+    back-ticks) so that e.g. ``true; vim``, ``echo x | less`` and ``$(vim)`` each surface
+    the ``vim``/``less`` invocation. Tokenization is quote-aware so operators inside a
+    quoted argument (``echo "a && vim"``) do not spuriously split the line.
+
+    Best-effort, lexical-only: this is used to harden a reliability filter (the
+    interactive-command blocklist), not as a security sandbox.
+    """
+    invocations: list[str] = []
+    # Recurse into command substitutions first; their inner commands are real
+    # invocations that the shell will run.
+    for match in _COMMAND_SUBSTITUTION_RE.finditer(action):
+        inner = match.group(1) if match.group(1) is not None else match.group(2)
+        if inner and inner.strip():
+            invocations.extend(_iter_command_invocations(inner))
+
+    # Quote-aware tokenization: operators become their own tokens, but operators that
+    # appear inside quotes stay part of the argument they belong to.
+    lexer = shlex.shlex(action, posix=True, punctuation_chars=True)
+    lexer.whitespace_split = True
+    try:
+        tokens = list(lexer)
+    except ValueError:
+        # Unbalanced quotes etc. -- fall back to the raw, naive operator split so we
+        # still surface the obvious invocations.
+        tokens = None
+    if tokens is None:
+        for segment in re.split(r"\|\||&&|\||;|&|\n", action):
+            segment = segment.strip()
+            if segment:
+                invocations.append(segment)
+        return invocations
+
+    current: list[str] = []
+    for token in tokens:
+        if token in _COMMAND_SEPARATOR_TOKENS:
+            if current:
+                invocations.append(" ".join(current))
+                current = []
+            continue
+        if token in _SUBSTITUTION_NOISE_TOKENS:
+            # Leftover ``$`` / ``(`` / ``)`` from a substitution we already handled above.
+            continue
+        current.append(token)
+    if current:
+        invocations.append(" ".join(current))
+    return invocations
+
+
+def _normalize_invocation(segment: str) -> str:
+    """Return ``segment`` with leading env-var assignments / wrapper programs removed and
+    the executable reduced to its basename.
+
+    e.g. ``/usr/bin/vim file`` -> ``vim file``, ``env FOO=bar vim`` -> ``vim``,
+    ``sudo nano /etc/hosts`` -> ``nano /etc/hosts``. Whitespace-normalized so that
+    prefix checks (``startswith``) and exact checks behave the same as on a plain
+    invocation. Returns the original (stripped) segment if it cannot be tokenized.
+    """
+    try:
+        tokens = shlex.split(segment)
+    except ValueError:
+        # Unbalanced quotes etc. -- fall back to a naive split so we still try to match.
+        tokens = segment.split()
+    index = 0
+    # Skip leading ``VAR=value`` environment assignments.
+    while index < len(tokens) and _ENV_ASSIGNMENT_RE.match(tokens[index]):
+        index += 1
+    # Skip wrapper programs (and their options / inline env assignments) so the wrapped
+    # command becomes the head, e.g. ``env -i FOO=bar vim`` -> ``vim``.
+    while index < len(tokens) and tokens[index] in _COMMAND_WRAPPERS:
+        index += 1
+        while index < len(tokens) and (tokens[index].startswith("-") or _ENV_ASSIGNMENT_RE.match(tokens[index])):
+            index += 1
+    if index >= len(tokens):
+        return segment.strip()
+    # Reduce the executable to its basename so path-qualified forms (``/usr/bin/vim``)
+    # match the same way bare names do.
+    tokens = tokens[index:]
+    tokens[0] = tokens[0].rsplit("/", 1)[-1]
+    return " ".join(tokens)
+
+
 class ToolHandler:
     def __init__(self, tools: ToolConfig):
         """This class handles most of the tool usage. It has the following responsibilities:
@@ -351,17 +454,46 @@ class ToolHandler:
     # --------
 
     def should_block_action(self, action: str) -> bool:
-        """Check if the command should be blocked."""
+        """Check if the command should be blocked.
+
+        The blocklist is a reliability filter that keeps the agent from launching
+        interactive/long-running programs (``vim``, ``less``, ``tail -f``, a bare
+        ``python`` REPL, ...) that would otherwise hang the run loop. To make the
+        decision consistent with what the shell actually executes, every individual
+        command in a compound command line is examined -- not just the first token --
+        and each is checked both as written and in a normalized form (path prefix and
+        ``env``/``sudo``-style wrappers stripped, executable reduced to its basename).
+        This closes lexical bypasses such as ``/usr/bin/vim``, ``env vim`` and
+        ``true; vim`` that the previous first-token-only check missed.
+        """
         action = action.strip()
         if not action:
             return False
-        if any(action.startswith(f) for f in self.config.filter.blocklist):
+        # The whole, original action is still checked first for backward compatibility
+        # with multi-word blocklist entries (e.g. "tail -f", "python -m venv").
+        candidates = [action]
+        for invocation in _iter_command_invocations(action):
+            candidates.append(invocation)
+            normalized = _normalize_invocation(invocation)
+            if normalized and normalized != invocation:
+                candidates.append(normalized)
+        for candidate in candidates:
+            if self._is_blocked_invocation(candidate):
+                return True
+        return False
+
+    def _is_blocked_invocation(self, candidate: str) -> bool:
+        """Apply the configured blocklist rules to a single command string."""
+        candidate = candidate.strip()
+        if not candidate:
+            return False
+        if any(candidate.startswith(f) for f in self.config.filter.blocklist):
             return True
-        if action in self.config.filter.blocklist_standalone:
+        if candidate in self.config.filter.blocklist_standalone:
             return True
-        name = action.split()[0]
+        name = candidate.split()[0]
         if name in self.config.filter.block_unless_regex and not re.search(
-            self.config.filter.block_unless_regex[name], action
+            self.config.filter.block_unless_regex[name], candidate
         ):
             return True
         return False

--- a/tests/test_should_block_action.py
+++ b/tests/test_should_block_action.py
@@ -1,0 +1,83 @@
+"""Tests for ``ToolHandler.should_block_action``.
+
+The blocklist is a reliability filter that stops the agent from launching
+interactive / long-running programs (``vim``, ``less``, ``tail -f``, a bare
+``python`` REPL, ...) that would hang the run loop. These tests pin down that the
+filter inspects every command in a compound command line and normalizes
+path-qualified / wrapper-prefixed invocations, so a blocked program cannot slip
+through simply by being written as ``/usr/bin/vim``, ``env vim`` or ``true; vim``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from sweagent.tools.parsing import FunctionCallingParser
+from sweagent.tools.tools import ToolConfig, ToolHandler
+
+
+@pytest.fixture
+def handler() -> ToolHandler:
+    return ToolHandler(ToolConfig(parse_function=FunctionCallingParser()))
+
+
+@pytest.mark.parametrize(
+    "action",
+    [
+        # bare forms (already blocked before the hardening)
+        "vim",
+        "python",
+        "tail -f log",
+        # path-qualified forms
+        "/usr/bin/vim file",
+        "/bin/sh",
+        # wrapper-prefixed forms
+        "env vim",
+        "env -i vim",
+        "FOO=bar /usr/bin/vim",
+        "sudo nano /etc/hosts",
+        "nice vim",
+        # operator-wrapped / compound forms
+        "x && vim",
+        "true; vim",
+        "echo hi | less",
+        "echo a || vim",
+        "cat f && less g",
+        "ls; tail -f log",
+        # command substitution
+        "$(vim)",
+        "`vim`",
+        "echo $(vim) done",
+    ],
+)
+def test_blocked_invocations(handler: ToolHandler, action: str):
+    assert handler.should_block_action(action) is True
+
+
+@pytest.mark.parametrize(
+    "action",
+    [
+        # ordinary, non-interactive commands must stay allowed
+        "ls -l",
+        "echo ok",
+        "cat file.py",
+        "grep -r foo .",
+        "git status",
+        # a blocklisted name as a *quoted argument* is not an invocation of it
+        'echo "a && vim"',
+        'grep "make" f',
+        'echo "tail -f"',
+        "git commit -m 'x; vim'",
+        # blocklisted names used as non-interactive subcommands stay allowed
+        "python script.py",
+        # radare2 is allowed when invoked with -c (existing block_unless_regex rule)
+        "radare2 -c px /bin/ls",
+    ],
+)
+def test_allowed_invocations(handler: ToolHandler, action: str):
+    assert handler.should_block_action(action) is False
+
+
+def test_empty_action_not_blocked(handler: ToolHandler):
+    assert handler.should_block_action("") is False
+    assert handler.should_block_action("   ") is False


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!
-->

#### Reference Issues/PRs
<!--
Example: "Fixes #1234", "See also #3456"
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

None — found while reading the tool-filtering code.

#### What does this implement/fix? Explain your changes.
<!--
Please include a brief explanation of how your solution
fixes the tagged issue(s), along with what files / entities have
been modified for this fix.
-->

**Summary.** This hardens `ToolHandler.should_block_action` so the
interactive-command blocklist sees the command line the way the shell will
actually run it. The blocklist is the reliability filter that stops the agent
from launching interactive / long-running programs (`vim`, `less`, `tail -f`, a
bare `python` REPL, `make`, ...) that would otherwise hang the run loop. Today
it only inspects the **first token of the whole action string** and normalizes
it with `action.strip()`, so a blocked program is still launched whenever the
model writes it in any non-bare shape.

**Scope (important).** This is **reliability hardening of an interactive-command
filter, not a security control.** The agent already has arbitrary shell
execution in its (Docker) environment by design — `handle_action` feeds
`step.action` straight into `env.communicate()` → `BashAction`. The blocklist
exists only to keep the run loop from stalling on interactive programs;
re-spelling a blocked command grants no extra capability. The change just makes
the filter robust to the obvious ways a command can be re-written so the agent
does not re-enter a program that hangs the run.

**Root cause.** The decision point and the execution point used different views
of the command string. The gate matched lexically against the first token only
(`startswith` over `blocklist`, exact match over `blocklist_standalone`), while
the shell runs the whole, fully-expanded command line. So path-qualified,
wrapper-prefixed, operator-wrapped and command-substitution forms all passed the
gate but ran normally:

- path-qualified: `/usr/bin/vim file`
- wrapper-prefixed: `env vim`, `sudo nano /etc/hosts`, `FOO=bar /usr/bin/vim`
- operator-wrapped / compound: `true; vim`, `echo x | less`, `cat f && less g`
- command substitution: `$(vim)`, `` `vim` ``

**Affected sites (decision point that under-normalized the command):**

- `sweagent/tools/tools.py:358` — `if any(action.startswith(f) for f in self.config.filter.blocklist):`
  (first-token-only lexical check; `action.strip()` only trims whitespace, so the
  wrapped/compound forms above are not recognized).

**The change (one place, `sweagent/tools/tools.py`).**

- `_iter_command_invocations(action)` splits a (possibly compound) command line
  into its individual invocations using a **quote-aware** tokenizer
  (`shlex.shlex(..., punctuation_chars=True)`) and also pulls out the inner
  commands of `$(...)` / back-tick substitutions. Quote-awareness means
  operators inside a quoted argument (`echo "a && vim"`) do **not** spuriously
  split the line; on unbalanced quotes it falls back to a naive split so obvious
  invocations still surface.
- `_normalize_invocation(segment)` strips leading `VAR=value` assignments and
  `env`/`sudo`/`nice`/`exec`/… wrapper programs (and their options) and reduces
  the executable to its **basename**, so `/usr/bin/vim` and `env vim` match the
  same rules a bare `vim` already does.
- `should_block_action` now checks the whole original action **first** (so
  multi-word blocklist entries like `tail -f` / `python -m venv` and the
  `block_unless_regex` rules behave exactly as before), **plus** each parsed
  invocation and its normalized form. The per-command rule logic itself is
  unchanged — it is just factored into `_is_blocked_invocation` and run against
  each candidate. One minimal change closes all of the wrapped/compound forms at
  once because they all reduce to a candidate the existing rules already match.

**Backwards compatibility.**

- No public API change: `should_block_action(action: str) -> bool` is identical;
  the new helpers are additive.
- `shlex` is in the standard library and is already imported elsewhere in the
  package.
- Existing allowed commands stay allowed — including `python script.py`,
  `radare2 -c …` (the `block_unless_regex` allow rule), and blocklisted names
  used as **quoted arguments** (`echo "tail -f"`, `git commit -m 'x; vim'`).
  Existing blocked bare forms stay blocked. Pre-existing over-blocks from the
  original `startswith` rule (e.g. `vimtutor`) are unchanged.

**Tests.** Adds `tests/test_should_block_action.py`:

- `test_blocked_invocations` (parametrized) — bare, path-qualified,
  wrapper-prefixed, operator-wrapped / compound, and command-substitution forms
  of blocklisted commands must be blocked. These cases **fail on `main`** and
  **pass with this change** (on BASE the file reports `15 failed, 16 passed`).
- `test_allowed_invocations` (parametrized) — ordinary commands, blocklisted
  names as quoted arguments, non-interactive subcommands, and the `radare2 -c`
  allow rule must NOT be blocked.
- `test_empty_action_not_blocked`.

Files modified: `sweagent/tools/tools.py` (the filter) and
`tests/test_should_block_action.py` (new test).

Verification (local, on this branch): the new test file passes (`31 passed`);
the broader `tests/test_agent.py` / `tests/test_parsing.py` /
`tests/test_tools_command_parsing.py` suites continue to pass (`57 passed, 2
xfailed`, the 2 xfails pre-existing and unrelated); `ruff check` and `ruff
format --check` are clean on the changed files.
