### PR TITLE
Fix NameError when tool call arguments are already a dict

### DIFF
--- a/sweagent/tools/parsing.py
+++ b/sweagent/tools/parsing.py
@@ -406,6 +406,8 @@ class FunctionCallingParser(AbstractParseFunction, BaseModel):
             except json.JSONDecodeError:
                 msg = "Tool call arguments are not valid JSON."
                 raise FunctionCallingFormatError(msg, "invalid_json")
+        else:
+            values = tool_call["function"]["arguments"]
         required_args = {arg.name for arg in command.arguments if arg.required}
         missing_args = required_args - values.keys()
         if missing_args:


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes a crash path related to #1159.

#### What does this implement/fix? Explain your changes.

`FunctionCallingParser._parse_tool_call` only assigns `values` when `arguments` is a JSON string. Some providers (via LiteLLM) pass an already-parsed `dict`, so the next line hits `NameError: name 'values' is not defined` and kills the run instead of returning a format error to the model.

Add the missing `else` branch to use the dict directly.

Made with [Cursor](https://cursor.com)