### PR TITLE
fix(tools): omit empty parameters.properties for Gemini

### DIFF
--- a/sweagent/tools/commands.py
+++ b/sweagent/tools/commands.py
@@ -158,7 +158,10 @@ class Command(BaseModel):
                 # Handle enum if present
                 if arg.enum:
                     properties[arg.name]["enum"] = arg.enum
-        tool["function"]["parameters"] = {"type": "object", "properties": properties, "required": required}
+        if properties:
+            tool["function"]["parameters"] = {"type": "object", "properties": properties, "required": required}
+        else:
+            tool["function"]["parameters"] = {"type": "object"}
         return tool
 
     @model_validator(mode="after")


### PR DESCRIPTION
## Summary

Gemini rejects function-calling tool schemas that include `"properties": {}` on zero-argument commands.

## Root cause

`Command.get_function_calling_tool()` always set `parameters` to `{"type": "object", "properties": properties, "required": required}` even when `properties` was empty. Vertex/Gemini requires the `properties` key to be omitted entirely for argument-less tools.

## Fix

Only include `properties` and `required` when the command has arguments; otherwise emit `{"type": "object"}`.

Fixes #941


Made with [Cursor](https://cursor.com)