### PR TITLE
Pin litellm to minimum safe version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ dependencies = [
     "pydantic",
     "python-dotenv",
     "pydantic_settings",
-    "litellm!=1.82.7,!=1.82.8",
+    "litellm>=1.44.12,!=1.82.7,!=1.82.8",
     "GitPython",
     "ghapi",
     "swe-rex>=1.4.0",


### PR DESCRIPTION
## Summary
- Require `litellm>=1.44.12` in `pyproject.toml` to prevent accidental downgrade to versions with known CVEs
- Keeps existing exclusions for broken releases `!=1.82.7,!=1.82.8`

## Test plan
- [ ] `pip install -e .` resolves to litellm >= 1.44.12
- [ ] Basic SWE-agent run with a litellm-backed model still works

Fixes #1429

Made with [Cursor](https://cursor.com)