### PR TITLE
feat: add SaveTrajectoryHook for remote environments

### DIFF
--- a/sweagent/run/hooks/save_trajectory.py
+++ b/sweagent/run/hooks/save_trajectory.py
@@ -1,0 +1,69 @@
+"""Hook for saving agent trajectories to the launching environment's filesystem."""
+
+import json
+import threading
+from pathlib import Path
+
+from sweagent.agent.problem_statement import ProblemStatementConfig
+from sweagent.environment.swe_env import SWEEnv
+from sweagent.run.hooks.abstract import RunHook
+from sweagent.types import AgentRunResult
+from sweagent.utils.log import get_logger
+
+
+class SaveTrajectoryHook(RunHook):
+    """Saves agent trajectories to the launching environment's filesystem.
+
+    For remote/cloud deployments the agent writes its ``.traj`` inside the
+    container's ``output_dir``; only the patch is brought back to the launching
+    environment via :class:`~sweagent.run.hooks.apply_patch.SaveApplyPatchHook`.
+    This hook is the trajectory equivalent: it runs in the launching environment
+    and persists the trajectory from the :class:`~sweagent.types.AgentRunResult`
+    that ``on_instance_completed`` receives, so no remote access is required.
+
+    The written document is ``{"trajectory": ..., "info": ...}``, i.e. the data
+    that ``AgentRunResult`` exposes. This is intentionally a subset of the richer
+    ``.traj`` that ``Agent.save_trajectory`` writes locally (which also includes
+    ``history``, the environment name and the replay config), so it is not
+    byte-identical to that file.
+    """
+
+    def __init__(self, pretty_print: bool = True):
+        """Initialize the SaveTrajectoryHook.
+
+        Args:
+            pretty_print: If True, formats JSON with indentation for readability.
+        """
+        self.logger = get_logger("swea-save_trajectory", emoji="📝")
+        self._pretty_print = pretty_print
+        # Thread-local storage so that concurrent workers in run-batch do not
+        # overwrite each other's per-instance state (_problem_statement).
+        self._local = threading.local()
+
+    def on_init(self, *, run):
+        self._output_dir = Path(run.output_dir)
+
+    def on_instance_start(self, *, index: int, env: SWEEnv, problem_statement: ProblemStatementConfig):
+        self._local.problem_statement = problem_statement
+
+    def on_instance_completed(self, *, result: AgentRunResult):
+        problem_statement = getattr(self._local, "problem_statement", None)
+        if problem_statement is None:
+            self.logger.warning("No problem statement available, skipping trajectory save.")
+            return
+        self._save_trajectory(problem_statement.id, result)
+
+    def _save_trajectory(self, instance_id: str, result: AgentRunResult) -> Path | None:
+        """Save trajectory data to a ``.traj`` file.
+
+        Returns:
+            The path to the trajectory file, if it was saved. Otherwise, returns None.
+        """
+        trajectory_output_dir = self._output_dir / instance_id
+        trajectory_output_dir.mkdir(exist_ok=True, parents=True)
+        trajectory_output_file = trajectory_output_dir / f"{instance_id}.traj"
+        trajectory_data = {"trajectory": result.trajectory, "info": result.info}
+        indent = 2 if self._pretty_print else None
+        trajectory_output_file.write_text(json.dumps(trajectory_data, indent=indent, ensure_ascii=False))
+        self.logger.info(f"Saved trajectory with {len(result.trajectory)} steps to {trajectory_output_file}")
+        return trajectory_output_file

--- a/tests/test_run_hooks.py
+++ b/tests/test_run_hooks.py
@@ -169,7 +169,7 @@ def test_swe_bench_evaluate_unsupported_subset_raises_value_error(tmp_path, subs
 
 def test_save_trajectory_hook_writes_to_per_instance_dir(tmp_path):
     hook = SaveTrajectoryHook()
-    hook._output_dir = tmp_path
+    hook.on_init(run=MagicMock(output_dir=tmp_path))
 
     ps = TextProblemStatement(text="Some issue", id="my-instance")
     hook.on_instance_start(index=0, env=MagicMock(), problem_statement=ps)
@@ -187,10 +187,31 @@ def test_save_trajectory_hook_writes_to_per_instance_dir(tmp_path):
     }
 
 
+def test_save_trajectory_hook_pretty_print_false_writes_compact_json(tmp_path):
+    hook = SaveTrajectoryHook(pretty_print=False)
+    hook.on_init(run=MagicMock(output_dir=tmp_path))
+
+    ps = TextProblemStatement(text="Some issue", id="compact-instance")
+    hook.on_instance_start(index=0, env=MagicMock(), problem_statement=ps)
+    result = AgentRunResult(
+        info={"submission": "patch", "exit_status": "submitted"},
+        trajectory=[],
+    )
+    hook.on_instance_completed(result=result)
+
+    traj_path = tmp_path / "compact-instance" / "compact-instance.traj"
+    content = traj_path.read_text()
+    assert "\n" not in content.rstrip("\n")
+    assert json.loads(content) == {
+        "trajectory": [],
+        "info": {"submission": "patch", "exit_status": "submitted"},
+    }
+
+
 def test_save_trajectory_hook_no_problem_statement_is_noop(tmp_path):
     """on_instance_completed must not raise (or write) when no instance started."""
     hook = SaveTrajectoryHook()
-    hook._output_dir = tmp_path
+    hook.on_init(run=MagicMock(output_dir=tmp_path))
 
     hook.on_instance_completed(result=AgentRunResult(info={}, trajectory=[]))
 
@@ -205,7 +226,7 @@ def test_save_trajectory_hook_concurrent_workers_save_to_correct_dirs(tmp_path):
     thread sees its own copy and writes to its own output directory.
     """
     hook = SaveTrajectoryHook()
-    hook._output_dir = tmp_path
+    hook.on_init(run=MagicMock(output_dir=tmp_path))
 
     barrier = threading.Barrier(2)
 

--- a/tests/test_run_hooks.py
+++ b/tests/test_run_hooks.py
@@ -1,3 +1,4 @@
+import json
 import os
 import threading
 from concurrent.futures import ThreadPoolExecutor
@@ -8,6 +9,7 @@ import pytest
 from sweagent.agent.problem_statement import GithubIssue, TextProblemStatement
 from sweagent.run.hooks.apply_patch import SaveApplyPatchHook
 from sweagent.run.hooks.open_pr import OpenPRConfig, OpenPRHook
+from sweagent.run.hooks.save_trajectory import SaveTrajectoryHook
 from sweagent.run.hooks.swe_bench_evaluate import SweBenchEvaluate
 from sweagent.types import AgentRunResult
 
@@ -163,3 +165,74 @@ def test_swe_bench_evaluate_unsupported_subset_raises_value_error(tmp_path, subs
     hook = SweBenchEvaluate(output_dir=tmp_path, subset=subset, split="dev")
     with pytest.raises(ValueError, match=subset):
         hook._get_sb_call(tmp_path / "preds.json")
+
+
+def test_save_trajectory_hook_writes_to_per_instance_dir(tmp_path):
+    hook = SaveTrajectoryHook()
+    hook._output_dir = tmp_path
+
+    ps = TextProblemStatement(text="Some issue", id="my-instance")
+    hook.on_instance_start(index=0, env=MagicMock(), problem_statement=ps)
+    result = AgentRunResult(
+        info={"submission": "patch", "exit_status": "submitted"},
+        trajectory=[],
+    )
+    hook.on_instance_completed(result=result)
+
+    traj_path = tmp_path / "my-instance" / "my-instance.traj"
+    assert traj_path.exists()
+    assert json.loads(traj_path.read_text()) == {
+        "trajectory": [],
+        "info": {"submission": "patch", "exit_status": "submitted"},
+    }
+
+
+def test_save_trajectory_hook_no_problem_statement_is_noop(tmp_path):
+    """on_instance_completed must not raise (or write) when no instance started."""
+    hook = SaveTrajectoryHook()
+    hook._output_dir = tmp_path
+
+    hook.on_instance_completed(result=AgentRunResult(info={}, trajectory=[]))
+
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_save_trajectory_hook_concurrent_workers_save_to_correct_dirs(tmp_path):
+    """Regression guard mirroring #1284 for SaveTrajectoryHook: concurrent
+    workers must not overwrite each other's per-instance ``_problem_statement``.
+
+    The hook stores per-instance state in ``threading.local()`` so every worker
+    thread sees its own copy and writes to its own output directory.
+    """
+    hook = SaveTrajectoryHook()
+    hook._output_dir = tmp_path
+
+    barrier = threading.Barrier(2)
+
+    def worker(instance_id: str, exit_status: str) -> None:
+        ps = TextProblemStatement(text=f"Issue for {instance_id}", id=instance_id)
+        hook.on_instance_start(index=0, env=MagicMock(), problem_statement=ps)
+
+        # Hold here until both threads have written their problem_statement so
+        # that the race window is guaranteed to be open.
+        barrier.wait()
+
+        result = AgentRunResult(
+            info={"exit_status": exit_status},
+            trajectory=[],
+        )
+        hook.on_instance_completed(result=result)
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        fa = pool.submit(worker, "instance-A", "status-A")
+        fb = pool.submit(worker, "instance-B", "status-B")
+        fa.result()
+        fb.result()
+
+    traj_a = tmp_path / "instance-A" / "instance-A.traj"
+    traj_b = tmp_path / "instance-B" / "instance-B.traj"
+
+    assert traj_a.exists(), "Trajectory for instance-A was not saved to its own directory"
+    assert traj_b.exists(), "Trajectory for instance-B was not saved to its own directory"
+    assert json.loads(traj_a.read_text())["info"]["exit_status"] == "status-A"
+    assert json.loads(traj_b.read_text())["info"]["exit_status"] == "status-B"


### PR DESCRIPTION
#### Reference Issues/PRs

Refs #1310

#### What does this implement/fix? Explain your changes.

In remote/cloud deployments the agent writes its `.traj` inside the container's `output_dir`, and only the patch comes back to the launching environment via `SaveApplyPatchHook`. There is no equivalent hook to persist the trajectory. #1310 sketches a `SaveTrajectoryHook` to close that gap.

This adds `SaveTrajectoryHook(RunHook)` (`sweagent/run/hooks/save_trajectory.py`), modeled on `SaveApplyPatchHook`:

- Runs in the launching environment. `on_init` captures `run.output_dir`; `on_instance_completed` writes `output_dir/<id>/<id>.traj` from the `AgentRunResult` it receives, so no remote/container access is needed.
- Per-instance state is kept in `threading.local()`, matching `SaveApplyPatchHook`, so concurrent run-batch workers do not clobber one another (cf. #1284).
- `pretty_print` toggle for the JSON output.

Two things I want to be upfront about:

1. **It is not auto-registered.** Local runs already write a richer `.traj` via `Agent.save_trajectory`, so wiring this on by default would double-write / overwrite that file. I left it unregistered and net-additive. Happy to wire it in wherever you prefer: an opt-in config flag, or always-on only for the remote deployment paths. What is your preference?
2. **The document is a subset**, `{"trajectory", "info"}`, which is what `AgentRunResult` exposes. The internal `.traj` also carries `history`, env and replay config, so this is not byte-identical to it. Documented in the docstring.

Tests added to `tests/test_run_hooks.py`: per-instance path, no-op when no problem statement, and a concurrency regression guard mirroring #1284. Targeted suite (`tests/test_run_hooks.py`) is green and ruff check/format are clean.

#### Test plan

- `uv run --no-sync pytest tests/test_run_hooks.py -q` -> 12 passed (3 new)
- `uvx ruff@0.15.17 check` + `format --check` on changed files -> clean
