### PR TITLE
fix: strip .git suffix when parsing GitHub repo URLs

### DIFF
--- a/sweagent/utils/github.py
+++ b/sweagent/utils/github.py
@@ -82,9 +82,8 @@ def _parse_gh_repo_url(repo_url: str) -> tuple[str, str]:
     if not match:
         msg = f"Invalid GitHub issue URL: {repo_url}"
         raise InvalidGithubURL(msg)
-    res = match.groups()
-    assert len(res) == 2
-    return tuple(res)  # type: ignore
+    owner, repo = match.groups()
+    return owner, repo.removesuffix(".git")
 
 
 def _get_gh_issue_data(issue_url: str, *, token: str = ""):

--- a/tests/test_env_utils.py
+++ b/tests/test_env_utils.py
@@ -39,6 +39,8 @@ def test_parse_gh_repo_url():
     assert _parse_gh_repo_url("github.com/SWE-agent/SWE-agent") == ("SWE-agent", "SWE-agent")
     assert _parse_gh_repo_url("github.com/SWE-agent/SWE-agent/asdfjsdfg") == ("SWE-agent", "SWE-agent")
     assert _parse_gh_repo_url("git@github.com/SWE-agent/SWE-agent/asdfjsdfg") == ("SWE-agent", "SWE-agent")
+    assert _parse_gh_repo_url("https://github.com/SWE-agent/SWE-agent.git") == ("SWE-agent", "SWE-agent")
+    assert _parse_gh_repo_url("github.com/SWE-agent/SWE-agent.git") == ("SWE-agent", "SWE-agent")
 
 
 def test_parse_gh_repo_url_fails():


### PR DESCRIPTION
#### Reference Issues/PRs

No existing issue, this is a small correctness fix I hit while reading the repo
URL handling. Happy to open a tracking issue first if you'd prefer.

#### What does this implement/fix? Explain your changes.

`_parse_gh_repo_url` (`sweagent/utils/github.py`) does not strip a trailing
`.git` from the repository name. The regex repo group is `([^/]+)`, so for the
URL you get from GitHub's green "Code" / clone button:

```python
_parse_gh_repo_url("https://github.com/SWE-agent/SWE-agent.git")
# returns ("SWE-agent", "SWE-agent.git")   <- note the trailing ".git"
```

The only caller is `GithubRepoConfig.repo_name`
(`sweagent/environment/repo.py`), which builds:

```python
return f"{org}__{repo}"   # -> "SWE-agent__SWE-agent.git"
```

That `repo_name` is then used in two ways that both end up wrong:

1. As the **instance id / output-directory name**, so trajectory and prediction
   paths get a stray `.git` baked into them.
2. As the **clone directory inside the sandbox**: `swe_env`/`repo.copy` run
   ``mkdir /{repo_name}`` and ``cd /{repo_name}`` (`repo.py`, `swe_env.py`), so
   the repo is actually checked out at `/SWE-agent__SWE-agent.git` instead of
   `/SWE-agent__SWE-agent`.

A `.git` clone URL is the most natural thing for a user to paste, and the bare
`org/repo.git` shorthand reaches the same code path (`model_post_init` only
rewrites it into a full `https://github.com/...` URL, it doesn't strip the
suffix), so this is easy to trip over.

The fix strips `.git` off the repo group only:

```python
owner, repo = match.groups()
return owner, repo.removesuffix(".git")
```

`str.removesuffix` is fine, the project's `requires-python` is `>=3.11`. I also
dropped the now-redundant `assert len(res) == 2` + `# type: ignore`: the
two-tuple unpacking is already type-safe, so mypy/pyright stay happy without it.
The owner group never carries `.git`, and because the repo group is greedy
`[^/]+`, the other forms stay correct (`.../o/r.git/` -> `r`,
`.../o/r/sub.git` -> `r`, plain `.../o/r` unchanged).

I extended the existing `test_parse_gh_repo_url` with the canonical `.git` URL
and the `org/repo.git` shorthand.

**Out of scope (kept deliberately):** the SSH colon form
`git@github.com:org/repo.git` still doesn't parse (the pattern matches on `/`
after `github.com`, not `:`). That's a pre-existing, separate limitation and I
didn't want to widen this PR; happy to follow up if it's wanted.

**Files changed**
- `sweagent/utils/github.py` - strip `.git` in `_parse_gh_repo_url`.
- `tests/test_env_utils.py` - 2 new asserts in `test_parse_gh_repo_url`.

**Testing**
```
uv run pytest tests/test_env_utils.py -q   # 9 passed
uv run ruff check sweagent/utils/github.py tests/test_env_utils.py
uv run ruff format --check sweagent/utils/github.py tests/test_env_utils.py
```
