### PR TITLE
fix: normalize patch line endings to LF at submission boundary

### DIFF
--- a/sweagent/agent/agents.py
+++ b/sweagent/agent/agents.py
@@ -840,7 +840,7 @@ class DefaultAgent(AbstractAgent):
             if "diff" not in last_trajectory_step["state"]:
                 self.logger.info("No diff in last trajectory step state, cannot autosubmit")
                 return step
-            diff = last_trajectory_step["state"]["diff"]
+            diff = last_trajectory_step["state"]["diff"].replace("\r\n", "\n").replace("\r", "\n")
             self.logger.info("Using diff from last trajectory step to autosubmit")
             step.submission = diff
             if step.submission:
@@ -891,6 +891,10 @@ class DefaultAgent(AbstractAgent):
             except Exception as e:
                 self.logger.exception("Failed to read submission file, got %s", e)
                 return step
+            # The patch is read from a pexpect/SWE-ReX terminal session that can introduce
+            # CR/CRLF line endings. Normalize to LF so the submission written to the graded
+            # SWE-bench prediction, the saved patch, and the trajectory is not CR-polluted (#702).
+            submission = submission.replace("\r\n", "\n").replace("\r", "\n")
             if submission.strip() != "":
                 step.submission = submission
             else:

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -11,6 +11,7 @@ from sweagent.agent.problem_statement import EmptyProblemStatement, TextProblemS
 from sweagent.environment.swe_env import SWEEnv
 from sweagent.tools.parsing import FunctionCallingParser, Identity, ThoughtActionParser
 from sweagent.tools.tools import ToolConfig
+from sweagent.types import StepOutput
 
 
 def test_dummy_env(dummy_env):
@@ -231,6 +232,26 @@ def test_successful_submission(dummy_env: SWEEnv, default_agent: DefaultAgent, t
     assert a.info["exit_status"] == "submitted"  # type: ignore
     assert a.info["submission"] == "test"  # type: ignore
     assert a.trajectory[-1]["observation"] == "test"
+
+
+def test_submission_strips_crlf(dummy_env: SWEEnv, default_agent: DefaultAgent, tmp_path):
+    """A patch read from the pexpect/SWE-ReX session may contain CR/CRLF. The submission
+    that ends up in the SWE-bench prediction, saved patch, and trajectory must be LF-only (#702)."""
+    a = default_agent
+    a.setup(dummy_env, EmptyProblemStatement())
+    a._env.read_file = lambda *args, **kwargs: "diff --git a/f b/f\r\n+line\rmore\n"  # type: ignore
+    step = a.handle_submission(StepOutput(), force_submission=True)
+    assert step.submission == "diff --git a/f b/f\n+line\nmore\n"
+    assert "\r" not in step.observation
+
+
+def test_submission_lf_unchanged(dummy_env: SWEEnv, default_agent: DefaultAgent, tmp_path):
+    a = default_agent
+    a.setup(dummy_env, EmptyProblemStatement())
+    patch = "diff --git a/f b/f\n+line\n"
+    a._env.read_file = lambda *args, **kwargs: patch  # type: ignore
+    step = a.handle_submission(StepOutput(), force_submission=True)
+    assert step.submission == patch
 
 
 def test_human_exit(dummy_env: SWEEnv, default_agent: DefaultAgent, tmp_path):


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #702

#### What does this implement/fix? Explain your changes.

**The bug.** The agent's final patch is read back from the sandbox with
`read_file("/root/model.patch")` in `DefaultAgent.handle_submission`. That file is
read over a `pexpect` / SWE-ReX terminal session, which can introduce `\r\n` (or
lone `\r`) line endings into the text. Nothing downstream strips them, so the
carriage returns flow, verbatim, into everything derived from the submission:

- the SWE-bench prediction file `<instance_id>.pred` (`model_patch`, written by
  `save_predictions`), which is the file the benchmark grades;
- the saved `<instance_id>.patch` (`SaveApplyPatchHook`);
- the saved trajectory.

CR-polluted patches can fail to apply cleanly with `git apply`, skew SWE-bench
grading, and (as @SlinkoIgor reported in #702) leak into trajectories that are
later collected for training. @SlinkoIgor is already running a local workaround
that normalizes the text, and @klieret confirmed pexpect is the source of the CRs.

**The fix.** Normalize line endings to LF at the single point where the patch
first enters Python, immediately after it is read in `handle_submission`:

```python
submission = submission.replace("\r\n", "\n").replace("\r", "\n")
```

Because every sink reads the same `info["submission"]` value
(`save_predictions`, `SaveApplyPatchHook._save_patch`, and the trajectory all
flow from `step_output.submission` set in `handle_submission`), normalizing once
at the source fixes the `.pred`, the `.patch`, and the trajectory together,
without touching any write site. The autosubmit fallback (the dead-runtime path
that pulls the diff from the last trajectory step) is normalized the same way, so
that path is covered too. The transform is idempotent for LF-only patches, so
there is no change for the common case.

This is a normalization at the point the value enters Python; it does not change
the lower-level pexpect / SWE-ReX behavior @klieret noted as the underlying cause,
it just ensures the produced patch is LF-only before it is used anywhere.

Files changed:
- `sweagent/agent/agents.py` - normalize `submission` after it is read in
  `handle_submission` (one line + a comment); normalize the autosubmit-diff
  fallback the same way.
- `tests/test_agent.py` - two tests: a CR/CRLF submission becomes LF-only
  (`test_submission_strips_crlf`), and an LF-only submission is unchanged
  (`test_submission_lf_unchanged`).
