### PR TITLE
docs: fix multimodal disable-image-processing flag hierarchy

### DIFF
--- a/docs/usage/multimodal.md
+++ b/docs/usage/multimodal.md
@@ -154,4 +154,4 @@ The `web_browser` bundle provides tools for:
 
 We've enabled multimodal processing when `--instances.type=swe-bench --instances.subset=multimodal` are set.
 
-To disable this behavior, you must set `--templates.disable_image_processing=true`.
+To disable this behavior, you must set `--agent.templates.disable_image_processing=true`.


### PR DESCRIPTION

<!-- Follows the repo's .github/PULL_REQUEST_TEMPLATE.md (Reference Issues/PRs; What does this implement/fix) -->

#### Reference Issues/PRs

None. This corrects a broken command in the multimodal docs that I hit while
following them; there was no existing issue or PR for it (the earlier multimodal
PRs, #1223 and #1092, add features rather than touch this flag).

#### What does this implement/fix? Explain your changes.

The "Disabling Image Processing" section of `docs/usage/multimodal.md` tells users
to disable image processing by running:

```
--templates.disable_image_processing=true
```

That flag is rejected by the CLI. `disable_image_processing` is a field on
`TemplateConfig` (`sweagent/agent/agents.py`), which is only reachable under
`agent.templates` (`DefaultAgentConfig.templates`). There is no top-level
`templates` field on the run config, and `RunSingleConfig` sets
`extra="forbid"` (`sweagent/run/run_single.py`), so the unprefixed flag fails
parsing instead of being silently ignored:

```
$ sweagent run --templates.disable_image_processing=true --problem_statement.text=hi
error parsing CLI: unrecognized arguments: --templates.disable_image_processing=true
- You forgot about part of the hierarchy (wrong: `--model.name`, correct: `--agent.model.name`)
```

The CLI's own hint points at exactly this class of mistake (the missing
hierarchy prefix). Notably, the YAML example a few lines earlier on the same page
already nests the option correctly under `agent: templates:`, so the CLI line was
just inconsistent with the page's own config example.

This change adds the missing `agent.` prefix so the documented command matches the
config hierarchy:

```
--agent.templates.disable_image_processing=true
```

With the prefix, the flag parses successfully (execution then continues normally).

**Files changed:** `docs/usage/multimodal.md` (one line).

Diff:

```diff
-To disable this behavior, you must set `--templates.disable_image_processing=true`.
+To disable this behavior, you must set `--agent.templates.disable_image_processing=true`.
```

Docs-only change, so no unit tests apply; verified by running both the old and new
commands against the real `sweagent run` CLI (old form is rejected with
`unrecognized arguments`; new form parses). `pre-commit` passes on the changed file.
