### PR TITLE
fix: normalize Content-Type parameters in multimodal image processing

### DIFF
--- a/sweagent/agent/problem_statement.py
+++ b/sweagent/agent/problem_statement.py
@@ -237,7 +237,8 @@ class SWEBenchMultimodalProblemStatement(_BuiltinProblemStatementBase):
             }
             response = requests.get(url, headers=headers, timeout=30, stream=True)
             response.raise_for_status()
-            content_type = response.headers.get("content-type", "").lower()
+            # strip any media type parameters (e.g. "image/png; charset=utf-8") before validation
+            content_type = response.headers.get("content-type", "").split(";")[0].strip().lower()
             if content_type == "image/jpg":
                 content_type = "image/jpeg"
             if content_type not in VALID_IMAGE_MIME_TYPES:

--- a/tests/test_problem_statement_multimodal.py
+++ b/tests/test_problem_statement_multimodal.py
@@ -44,6 +44,23 @@ class TestSWEBenchMultimodalProblemStatement:
         assert f"![{self.example_image_url}](data:image/png;base64," in result
 
     @patch("requests.get")
+    def test_get_problem_statement_with_content_type_parameters(self, mock_get):
+        """Test that a Content-Type header with media type parameters is still accepted."""
+        # servers may append parameters like charset, which is legal per RFC 9110
+        mock_response = Mock()
+        mock_response.raise_for_status.return_value = None
+        mock_response.headers = {"content-type": "image/png; charset=utf-8"}
+        mock_response.iter_content.return_value = [b"fake_image_data"]
+        mock_get.return_value = mock_response
+        problem_statement = SWEBenchMultimodalProblemStatement(
+            text="Test problem statement", issue_images=[self.example_image_url]
+        )
+        result = problem_statement.get_problem_statement()
+        # the parameters should be stripped before validation and encoding
+        assert "Test problem statement" in result
+        assert f"![{self.example_image_url}](data:image/png;base64," in result
+
+    @patch("requests.get")
     def test_get_problem_statement_with_network_error(self, mock_get):
         """Test that network errors are handled gracefully with warnings."""
         # mock network error


### PR DESCRIPTION

```markdown
#### Reference Issues/PRs

Closes #1441

#### What does this implement/fix? Explain your changes.

`SWEBenchMultimodalProblemStatement._download_and_convert_image()` compared the
full lowercased `Content-Type` header against `VALID_IMAGE_MIME_TYPES`. When a
server returns a valid image but includes media type parameters (for example
`Content-Type: image/png; charset=utf-8`, which is legal per RFC 9110), the
string `"image/png; charset=utf-8"` is not in the allowed set, so the image is
logged as an unsupported MIME type and silently dropped from the problem
statement.

This strips the media type parameters (split on `;`, strip, lowercase) at the
single point where the header is read, before the existing
`image/jpg` -> `image/jpeg` normalization and the membership check. The bare
media type is then validated and used in the encoded data URI, so a valid image
with a charset (or any other) parameter is processed instead of dropped.

Behavior for unsupported types, size limits, empty images, and network failures
is unchanged.

Files changed:
- `sweagent/agent/problem_statement.py`: normalize the media type before
  validation (1 line changed, 1 comment added).
- `tests/test_problem_statement_multimodal.py`: add a regression test covering a
  `Content-Type` header with a `charset` parameter, mirroring the existing
  valid-image test.
```

---

## The change (for reviewers)

`sweagent/agent/problem_statement.py`, in `_download_and_convert_image`:

```diff
-            content_type = response.headers.get("content-type", "").lower()
+            # strip any media type parameters (e.g. "image/png; charset=utf-8") before validation
+            content_type = response.headers.get("content-type", "").split(";")[0].strip().lower()
```

The existing `image/jpg` -> `image/jpeg` normalization, the
`VALID_IMAGE_MIME_TYPES` membership check, and the `data:{content_type};base64,`
data URI all consume `content_type` immediately after, so normalizing at this one
line fixes validation and encoding together with no other multimodal behavior
touched.

Regression test `test_get_problem_statement_with_content_type_parameters` mocks
`requests.get` with `{"content-type": "image/png; charset=utf-8"}` and asserts
`data:image/png;base64,` appears in `get_problem_statement()`. It fails on `main`
(image dropped) and passes with the fix.

---

## Verification (done locally)

- `uv run --no-sync pytest tests/test_problem_statement_multimodal.py -q` => 9 passed.
- Red->green proven: reverting only the source line makes the new test fail with
  the exact reported symptom (`Unsupported image MIME type 'image/png;
  charset=utf-8' ... Not encoding image.`); restoring makes the suite green again.
- Edge cases checked (pure, no network): params stripped, `image/jpg` alias still
  maps to `image/jpeg` (bare and with params), case-insensitive, empty header and
  `text/html; ...` still correctly rejected, whitespace handled by `.strip()`.
- `uvx ruff@0.15.20 check` => all checks passed; `ruff format --check` => already
  formatted (pin matches `.pre-commit-config.yaml`).
- `uvx pre-commit run --files <both files>` => all hooks passed (check-ast,
  trailing-whitespace, mixed-line-ending, detect-private-key, typos, ruff,
  ruff-format).
