### PR TITLE
docs: fix removed problem_statement flags in command line tutorial

### DIFF
--- a/docs/usage/cl_tutorial.md
+++ b/docs/usage/cl_tutorial.md
@@ -146,8 +146,8 @@ in addition to all the other `--config` options for the two examples above.
 We've already seen a few examples of how to specify the problem to solve, namely
 
 ```bash
---problem_statement.data_path /path/to/problem.md
---problem_statement.repo_path /path/to/repo
+--problem_statement.github_url=https://github.com/SWE-agent/test-repo/issues/1
+--problem_statement.path=/path/to/problem.md
 --problem_statement.text="..."
 ```
 


### PR DESCRIPTION

#### Reference Issues/PRs

None. No open issue; this is a standalone docs-correctness fix found while
reading the command line tutorial.

#### What does this implement/fix? Explain your changes.

The "Problem statements and union types" section of the command line tutorial
(`docs/usage/cl_tutorial.md`) shows a few examples of how to specify the problem
to solve. Two of the three example flags do not exist and now hard-error:

```bash
--problem_statement.data_path /path/to/problem.md
--problem_statement.repo_path /path/to/repo
--problem_statement.text="..."
```

The three problem statement types (`TextProblemStatement`, `GithubIssue`,
`FileProblemStatement`) only expose `text`, `path`, and `github_url`. `data_path`
and `repo_path` are the pre-1.0 names that were removed: `RunSingleConfig`'s
auto-correct table in `sweagent/run/run_single.py` explicitly rejects them and
points users to the new flags. Running either one fails with an "unrecognized
arguments" error. `repo_path` was also a repository option (it belongs on
`--env.repo.*`), not a problem statement option, and the repository is already
documented separately in the "Specifying the repository" section just below.

This replaces the two dead flags with the flags that map one-to-one to the union
members listed immediately below the block (`GithubIssue`, `FileProblemStatement`,
`TextProblemStatement`):

```bash
--problem_statement.github_url=https://github.com/SWE-agent/test-repo/issues/1
--problem_statement.path=/path/to/problem.md
--problem_statement.text="..."
```

The `github_url` example reuses the `SWE-agent/test-repo/issues/1` URL already
used elsewhere in the same file, and the `=` form matches the other valid
examples in the tutorial and `sweagent run --help`.

Only `docs/usage/cl_tutorial.md` is changed (+2 / -2).
