### PR TITLE
docs: fix traj-to-demo command in demonstrations guide

### DIFF
--- a/docs/config/demonstrations.md
+++ b/docs/config/demonstrations.md
@@ -31,7 +31,7 @@ Here's how you can make a demo from an existing trajectory file (like the one cr
 1. Find a basic trajectory that you already like and want to use as the basis for your demo.
    For instance, consider the `.traj` files in the [`trajectories/demonstrations/` folder](https://github.com/SWE-agent/SWE-agent/tree/main/trajectories/demonstrations)
    or find the trajectory from the previous step (the path will be printed at the bottom).
-2. Run `sweagent traj-to-demo --traj_path<path to trajectory file.traj>` to convert the trajectory to a demo.
+2. Run `sweagent traj-to-demo <path to trajectory file.traj>` to convert the trajectory to a demo.
    This demo will be saved as a readable yaml file in the `demos/` directory.
 3. Edit the demo by hand to make it work for your particular use case and configuration.
 4. (Optional) Run `sweagent run-replay --traj_path <path to demo>` to execute the actions of the demo, have the system generate the execution output, and ensure that it works as expected.


### PR DESCRIPTION

<!-- Two H4 sections, matching the repo template exactly. -->

#### Reference Issues/PRs

No existing issue: I hit this while following the demonstrations guide. No open PR
touches this doc or command (the merged #525 fixed `--traj_path` in `run_replay.py`,
which is a different command and left untouched here).

#### What does this implement/fix? Explain your changes.

The "Creating demonstrations from a trajectory" guide documents the conversion
command as:

```
sweagent traj-to-demo --traj_path<path to trajectory file.traj>
```

Copying that verbatim fails argument parsing:

```
sweagent: error: the following arguments are required: traj_path
```

`traj-to-demo` is argparse-based and declares `traj_path` as a **positional**
argument (`sweagent/run/run_traj_to_demo.py`), not a `--traj_path` option, so the
`--traj_path` form is unrecognized. The documented string also glues the flag to
the placeholder with no space.

This changes the documented command to the positional form so it runs as written:

```
sweagent traj-to-demo <path to trajectory file.traj>
```

`sweagent traj-to-demo --help` confirms `traj_path` is listed under "positional
arguments".

The next `run-replay --traj_path <path to demo>` step (line 37) is intentionally
left unchanged: `run-replay` is pydantic-settings based (`RunReplayConfig`) and does
expose a real `--traj_path` field, so that flag is correct there.

Only one line of `docs/config/demonstrations.md` changed.
