### PR TITLE
fix: reject malformed view_range in XMLFunctionCallingParser

### DIFF
--- a/sweagent/tools/parsing.py
+++ b/sweagent/tools/parsing.py
@@ -285,7 +285,7 @@ class XMLFunctionCallingParser(AbstractParseFunction, BaseModel):
             # Check that value is format as [x, y]
             v = params_dict["view_range"]
             if isinstance(v, str):
-                if not re.match(r"\[\d+,\s*\d+\]", v):
+                if not re.fullmatch(r"\[\d+,\s*\d+\]", v):
                     msg = f"view_range must be in the format [<start>, <end>], got {v}."
                     raise FormatError(msg)
                 params_dict["view_range"] = json.loads(v)

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -4,7 +4,7 @@ import pytest
 from jinja2 import Template
 
 from sweagent.exceptions import FormatError, FunctionCallingFormatError
-from sweagent.tools.commands import Command
+from sweagent.tools.commands import Argument, Command
 from sweagent.tools.parsing import (
     ActionParser,
     EditFormat,
@@ -12,6 +12,7 @@ from sweagent.tools.parsing import (
     Identity,
     JsonParser,
     ThoughtActionParser,
+    XMLFunctionCallingParser,
     XMLThoughtActionParser,
 )
 
@@ -129,3 +130,42 @@ def test_function_calling_parser_error_message():
     template = Template(FunctionCallingParser().error_message)
     exc1 = FunctionCallingFormatError("test", "missing")
     assert "did not use any tool calls" in template.render(**exc1.extra_info, exception_message=exc1.message)
+
+
+def _view_range_command() -> Command:
+    return Command(
+        name="view",
+        docstring="View a file.",
+        signature="view <path> <view_range>",
+        arguments=[
+            Argument(name="path", type="string", description="File path.", required=True),
+            Argument(name="view_range", type="array", description="Line range.", required=True),
+        ],
+    )
+
+
+def _xml_view_range_response(view_range: str) -> dict:
+    return {
+        "message": (
+            "Let's view the file.\n"
+            "<function=view>\n"
+            "<parameter=path>/testbed/file.py</parameter>\n"
+            f"<parameter=view_range>{view_range}</parameter>\n"
+            "</function>"
+        )
+    }
+
+
+def test_xml_function_calling_parser_view_range():
+    parser = XMLFunctionCallingParser()
+    command = _view_range_command()
+
+    # A well-formed view_range parses into the command invocation.
+    _, action = parser(_xml_view_range_response("[1, 20]"), [command])
+    assert action == "view /testbed/file.py [1, 20]"
+
+    # A value with trailing content after a valid [<int>, <int>] prefix must raise
+    # FormatError (so the model is re-queried), not an uncaught JSONDecodeError.
+    for malformed in ("[1,2]extra", "[1, 2] and more"):
+        with pytest.raises(FormatError):
+            parser(_xml_view_range_response(malformed), [command])


### PR DESCRIPTION

<!-- follows .github/PULL_REQUEST_TEMPLATE.md -->

#### Reference Issues/PRs

None. This is a self-contained fix; I did not find an existing issue or PR for
it. It is a sibling of the `FunctionCallingParser` argument-handling work in
#1417 / #1182, but it is a different parser and a different code path, so it does
not overlap with that PR.

#### What does this implement/fix? Explain your changes.

`XMLFunctionCallingParser` validates the `view_range` parameter with an
`re.match` that is only anchored at the start of the string:

```python
# sweagent/tools/parsing.py
v = params_dict["view_range"]
if isinstance(v, str):
    if not re.match(r"\[\d+,\s*\d+\]", v):
        msg = f"view_range must be in the format [<start>, <end>], got {v}."
        raise FormatError(msg)
    params_dict["view_range"] = json.loads(v)
```

Because `re.match` is unanchored at the end, a value that starts with a valid
`[<int>, <int>]` prefix but has trailing junk, for example `"[1,2]extra"` or
`"[1, 2] and more"`, passes the format check. It is then handed to
`json.loads`, which is not valid JSON for a two-element list and raises
`json.JSONDecodeError`.

That exception is the problem. `JSONDecodeError` is a subclass of `ValueError`,
not `FormatError`. The parser is supposed to raise `FormatError` here so the
agent catches it and re-queries the model to fix its output format. The uncaught
`JSONDecodeError` instead falls through to the broad error handler, which aborts
the whole run for that instance via the auto-submission/exit path. So a model
that emits a `view_range` with a valid numeric prefix plus stray trailing
characters makes SWE-agent give up on the instance instead of nudging the model
to correct the format.

The fix is one line: use `re.fullmatch` so the whole string must conform. Any
malformed `view_range` now takes the existing `FormatError` branch (with the
already-present, helpful message) instead of reaching `json.loads`.

Changes:
- `sweagent/tools/parsing.py`: `re.match` -> `re.fullmatch` in the
  `XMLFunctionCallingParser` `view_range` validation.
- `tests/test_parsing.py`: add `test_xml_function_calling_parser_view_range`,
  which drives the parser end-to-end and asserts a well-formed value
  (`[1, 20]`) parses into the action, while `[1,2]extra` and `[1, 2] and more`
  raise `FormatError` (previously they raised an uncaught `JSONDecodeError`).

One small, intended behavior change worth calling out: `re.fullmatch` also
rejects a trailing space, for example `"[1,2] "`, which `json.loads` used to
accept (JSON ignores trailing whitespace). This now yields a clean `FormatError`
re-query rather than silent acceptance, which matches the documented format
`[<start>, <end>]`.

Tested with `pytest tests/test_parsing.py` (9 passed); `ruff check` and
`ruff format` are clean on the changed files.
