### PR TITLE
docs: nest tool bundles under agent.tools in custom tools tutorial

### DIFF
--- a/docs/usage/adding_custom_tools.md
+++ b/docs/usage/adding_custom_tools.md
@@ -108,6 +108,7 @@ agent:
       Don't forget to use `print_cat` when you need encouragement!
 
       Your thinking should be thorough and so it's fine if it's very long.
+  tools:
     bundles:
       - path: tools/registry
       - path: tools/edit_anthropic


### PR DESCRIPTION

#### Reference Issues/PRs

None. I noticed this while following the "Adding Custom Tools" tutorial, so there is no existing issue. Happy to open one first if maintainers prefer.

#### What does this implement/fix? Explain your changes.

The example config in Step 3 of the "Adding Custom Tools" tutorial (`docs/usage/adding_custom_tools.md`) nests the `bundles:` block one level too shallow. As written, `bundles:` is indented as a child of `agent.templates` (a sibling of `instance_template:`) instead of `agent.tools`:

```yaml
agent:
  templates:
    instance_template: |-
      (...)
    bundles:            # <- ends up under agent.templates
      - path: tools/registry
      - path: tools/morale_boost  # Add our custom tool bundle!
```

But `bundles` is a field of `ToolConfig`, not `TemplateConfig` (see `sweagent/tools/tools.py`), and the shipped `config/default.yaml` places it under `agent.tools`. Because `TemplateConfig` (in `sweagent/agent/agents.py`) does not set `extra="forbid"`, pydantic falls back to its default `extra="ignore"` and silently drops the misplaced `bundles` key. There is no error or warning.

The practical impact: a reader who copies this snippet's structure never actually loads the `morale_boost` tool they just built, so the whole tutorial silently does nothing. I confirmed against the real models that loading the config as written yields zero bundles under `tools`, while the corrected nesting loads them.

The fix adds the missing `tools:` parent (a 2-space sibling of `templates:`) so the pre-existing `bundles:` block sits under `agent.tools`, matching `config/default.yaml`:

```yaml
agent:
  templates:
    instance_template: |-
      (...)
  tools:
    bundles:
      - path: tools/registry
      - path: tools/morale_boost  # Add our custom tool bundle!
```

Files modified:
- `docs/usage/adding_custom_tools.md` (docs only, +1 line).

Docs-only change, so there is no code path to add a regression test for.
