### PR TITLE
fix: strip URL query string and fragment when parsing GitHub repo URLs

### DIFF
--- a/sweagent/utils/github.py
+++ b/sweagent/utils/github.py
@@ -83,7 +83,7 @@ def _parse_gh_repo_url(repo_url: str) -> tuple[str, str]:
         msg = f"Invalid GitHub issue URL: {repo_url}"
         raise InvalidGithubURL(msg)
     owner, repo = match.groups()
-    return owner, repo.removesuffix(".git")
+    return owner, repo.split("?", 1)[0].split("#", 1)[0].removesuffix(".git")
 
 
 def _get_gh_issue_data(issue_url: str, *, token: str = ""):

--- a/tests/test_env_utils.py
+++ b/tests/test_env_utils.py
@@ -41,6 +41,9 @@ def test_parse_gh_repo_url():
     assert _parse_gh_repo_url("git@github.com/SWE-agent/SWE-agent/asdfjsdfg") == ("SWE-agent", "SWE-agent")
     assert _parse_gh_repo_url("https://github.com/SWE-agent/SWE-agent.git") == ("SWE-agent", "SWE-agent")
     assert _parse_gh_repo_url("github.com/SWE-agent/SWE-agent.git") == ("SWE-agent", "SWE-agent")
+    assert _parse_gh_repo_url("https://github.com/SWE-agent/SWE-agent?ref=main") == ("SWE-agent", "SWE-agent")
+    assert _parse_gh_repo_url("https://github.com/SWE-agent/SWE-agent#readme") == ("SWE-agent", "SWE-agent")
+    assert _parse_gh_repo_url("https://github.com/SWE-agent/SWE-agent.git?ref=main") == ("SWE-agent", "SWE-agent")
 
 
 def test_parse_gh_repo_url_fails():


### PR DESCRIPTION

#### Reference Issues/PRs

Fixes #1444. Follow-up to #1442 (which stripped the `.git` suffix in the same
function); this handles the sibling query-string / fragment case.

#### What does this implement/fix? Explain your changes.

`_parse_gh_repo_url` (`sweagent/utils/github.py`) only strips a trailing `.git`
from the repository name. The regex repo group is `([^/]+)`, so a GitHub URL
that carries a query string or fragment keeps it in the repo name:

```python
_parse_gh_repo_url("https://github.com/SWE-agent/SWE-agent?ref=main")
# returns ("SWE-agent", "SWE-agent?ref=main")

_parse_gh_repo_url("https://github.com/SWE-agent/SWE-agent#readme")
# returns ("SWE-agent", "SWE-agent#readme")
```

The only caller is `GithubRepoConfig.repo_name` (`sweagent/environment/repo.py`),
which builds `f"{org}__{repo}"`, so the stray `?ref=main` / `#readme` gets baked
in. That `repo_name` is then used in two ways that both go wrong:

1. As the **instance id / output-directory name**, so trajectory and prediction
   paths get the query/fragment baked into them.
2. As the **clone directory inside the sandbox**: `copy()` runs
   ``mkdir /{repo_name}`` under `shell=True` (`repo.py`), so the `?` is treated
   as a shell glob and `#` starts a comment, putting the checkout at an
   unexpected path.

Links with a `?ref=`/`#anchor` are easy to paste (they are what you get when you
copy a URL for a specific branch, tag, or a heading on the repo page), and the
`org/repo?ref=...` shorthand reaches the same code path, so this is easy to trip
over.

The fix splits off the query string and fragment before removing `.git`, so
these URLs resolve to `("owner", "repo")`:

```python
owner, repo = match.groups()
return owner, repo.split("?", 1)[0].split("#", 1)[0].removesuffix(".git")
```

Order matters: strip `?query` / `#fragment` first, then `.git`, so a combined
`repo.git?ref=main` also resolves to `repo`. Because the repo group is greedy
`[^/]+`, the other forms stay correct (plain `.../o/r` unchanged, `.../o/r.git`
still `r`).

**Files changed**
- `sweagent/utils/github.py` - split off `?`/`#` before `.git` removal in
  `_parse_gh_repo_url`.
- `tests/test_env_utils.py` - 3 new asserts in `test_parse_gh_repo_url`
  (`?ref=main`, `#readme`, `.git?ref=main`).

**Testing**
```
uv run pytest tests/test_env_utils.py -q   # passes (network test deselected here)
uv run ruff check sweagent/utils/github.py tests/test_env_utils.py
uv run ruff format --check sweagent/utils/github.py tests/test_env_utils.py
```
