### PR TITLE
fix: fully validate command argument names

### DIFF
--- a/sweagent/tools/commands.py
+++ b/sweagent/tools/commands.py
@@ -196,7 +196,7 @@ class Command(BaseModel):
             msg = f"Command '{self.name}': Duplicate argument names: {duplicates}"
             raise ValueError(msg)
         for arg in self.arguments:
-            if not re.match(ARGUMENT_NAME_PATTERN, arg.name):
+            if not re.fullmatch(ARGUMENT_NAME_PATTERN, arg.name):
                 msg = f"Command '{self.name}': Invalid argument name: '{arg.name}'"
                 raise ValueError(msg)
         if (invoke_keys := _extract_keys(self.invoke_format)) != {arg.name for arg in self.arguments}:

--- a/tests/test_tools_command_parsing.py
+++ b/tests/test_tools_command_parsing.py
@@ -92,8 +92,9 @@ def test_argument_name_patterns():
         )
         assert command.arguments[0].name == name
 
-    # Invalid names
-    invalid_names = ["123starts_with_number", ""]
+    # Invalid names, including names that only become invalid after a valid prefix
+    # (these are accepted by re.match but must be rejected by re.fullmatch)
+    invalid_names = ["123starts_with_number", "", "arg name", "a/b", "arg;rm -rf", "arg$name"]
 
     for name in invalid_names:
         with pytest.raises(ValueError, match="Invalid argument name"):


### PR DESCRIPTION
#### Reference Issues/PRs

No existing issue. This is a small correctness fix found while reviewing command argument validation.

#### What does this implement/fix? Explain your changes.

`Command.validate_arguments` used `re.match` with `ARGUMENT_NAME_PATTERN`, which only validates a prefix of the argument name. Names such as `"arg name"`, `"a/b"`, and `"arg$name"` therefore passed validation and produced malformed invocation formats that failed later with less useful errors.

This changes the check to `re.fullmatch` so the entire argument name must conform to the existing pattern. It also extends `test_argument_name_patterns` with names that have a valid prefix followed by invalid characters. Existing valid names, including dashed names such as `replace-all`, remain accepted.
