### PR TITLE
fix: read host-side input files as UTF-8

### DIFF
--- a/sweagent/agent/agents.py
+++ b/sweagent/agent/agents.py
@@ -627,7 +627,7 @@ class DefaultAgent(AbstractAgent):
 
         # Load history
         self.logger.info(f"DEMONSTRATION: {demonstration_path}")
-        _demo_text = Path(demonstration_path).read_text()
+        _demo_text = Path(demonstration_path).read_text(encoding="utf-8")
         if demonstration_path.suffix == ".yaml":
             demo_history = yaml.safe_load(_demo_text)["history"]
         else:

--- a/sweagent/run/common.py
+++ b/sweagent/run/common.py
@@ -290,7 +290,7 @@ class BasicCLI:
         if cli_args.config:
             config_files.extend(cli_args.config)
             for _f in cli_args.config:
-                txt = Path(_f).read_text()
+                txt = Path(_f).read_text(encoding="utf-8")
                 if not txt.strip():
                     self.logger.warning(f"Config file {_f} is empty")
                     continue
@@ -304,7 +304,7 @@ class BasicCLI:
                 "config file is specified. Specify --no_config_file to disable this."
             )
             self.logger.info(msg)
-            txt = config_file.read_text()
+            txt = config_file.read_text(encoding="utf-8")
             if not txt.strip():
                 self.logger.warning(f"Default config file {config_file} is empty")
                 config_merged = {}

--- a/sweagent/utils/files.py
+++ b/sweagent/utils/files.py
@@ -18,10 +18,10 @@ def load_file(path: Path | str | None) -> Any:
 
         return load_from_disk(path)
     if path.suffix in [".json", ".traj"]:
-        return json.loads(path.read_text())
+        return json.loads(path.read_text(encoding="utf-8"))
     if path.suffix == ".jsonl":
-        return [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
+        return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
     if path.suffix == ".yaml":
-        return yaml.safe_load(path.read_text())
+        return yaml.safe_load(path.read_text(encoding="utf-8"))
     msg = f"Unsupported file extension: {path.suffix}"
     raise NotImplementedError(msg)

--- a/tests/test_utils_files.py
+++ b/tests/test_utils_files.py
@@ -1,0 +1,26 @@
+import pytest
+
+from sweagent.utils.files import load_file
+
+
+@pytest.mark.parametrize(
+    ("suffix", "content"),
+    [
+        (".json", '{"problem_statement": "Fix the café — please"}'),
+        (".traj", '{"problem_statement": "Fix the café — please"}'),
+        (".yaml", "problem_statement: Fix the café — please"),
+    ],
+)
+def test_load_file_reads_utf8(tmp_path, suffix, content):
+    path = tmp_path / f"instance{suffix}"
+    path.write_text(content, encoding="utf-8")
+    assert load_file(path) == {"problem_statement": "Fix the café — please"}
+
+
+def test_load_jsonl_reads_utf8(tmp_path):
+    path = tmp_path / "instances.jsonl"
+    instances = [{"problem_statement": "Fix the café"}, {"problem_statement": "Keep the em dash — intact"}]
+    path.write_text(
+        '{"problem_statement": "Fix the café"}\n{"problem_statement": "Keep the em dash — intact"}', encoding="utf-8"
+    )
+    assert load_file(path) == instances


### PR DESCRIPTION
#### Reference Issues/PRs

No existing issue. This is the same locale-dependent file-reading problem fixed in mini-swe-agent #892, in SWE-agent's host-side input paths.

#### What does this implement/fix? Explain your changes.

Several host-side files were read without an explicit encoding, so Python used the machine's locale. On Windows systems using a legacy code page, UTF-8 config files, demonstrations, and instance files containing non-ASCII text could fail to load or be decoded incorrectly.

This reads those files explicitly as UTF-8:

- CLI config files
- YAML and trajectory demonstrations
- JSON, JSONL, YAML, and trajectory instance files

The write paths are unchanged. Added regression coverage for literal UTF-8 content across the shared instance-file loader.

Tested with:

- `pytest tests/test_utils_files.py tests/test_agent.py -q`: 15 passed, 2 xfailed
- Ruff lint on all changed files
- `git diff --check`