### PR TITLE
fix: forward configured stop sequences to litellm.completion

### DIFF
--- a/sweagent/agent/models.py
+++ b/sweagent/agent/models.py
@@ -705,6 +705,9 @@ class LiteLLMModel(AbstractModel):
         if self.config.api_base:
             # Not assigned a default value in litellm, so only pass this if it's set
             extra_args["api_base"] = self.config.api_base
+        if self.config.stop:
+            # Only pass custom stop sequences if configured, so the default behavior is unchanged
+            extra_args["stop"] = self.config.stop
         if self.tools.use_function_calling:
             extra_args["tools"] = self.tools.tools
         # We need to always set max_tokens for anthropic models

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -104,3 +104,43 @@ def test_user_agent_header_with_other_extra_headers():
         extra_headers = call_kwargs.kwargs.get("extra_headers", {})
         assert extra_headers["User-Agent"] == f"swe-agent/{__version__}"
         assert extra_headers["X-Custom"] == "value"
+
+
+def test_stop_sequences_forwarded():
+    """Configured stop sequences are forwarded to litellm.completion."""
+    stop = ["Human:", "AI:"]
+    model = get_model(
+        GenericAPIModelConfig(
+            name="gpt-4o",
+            api_key=SecretStr("dummy_key"),
+            top_p=None,
+            stop=stop,
+            per_instance_cost_limit=0,
+            total_cost_limit=0,
+        ),
+        ToolConfig(parse_function=Identity()),
+    )
+    mock_response = _make_mock_response()
+    with patch("litellm.completion", return_value=mock_response) as mock_completion:
+        model.query(History([{"role": "user", "content": "test"}]))
+        mock_completion.assert_called_once()
+        assert mock_completion.call_args.kwargs.get("stop") == stop
+
+
+def test_stop_sequences_omitted_by_default():
+    """No stop kwarg is passed to litellm.completion when none are configured."""
+    model = get_model(
+        GenericAPIModelConfig(
+            name="gpt-4o",
+            api_key=SecretStr("dummy_key"),
+            top_p=None,
+            per_instance_cost_limit=0,
+            total_cost_limit=0,
+        ),
+        ToolConfig(parse_function=Identity()),
+    )
+    mock_response = _make_mock_response()
+    with patch("litellm.completion", return_value=mock_response) as mock_completion:
+        model.query(History([{"role": "user", "content": "test"}]))
+        mock_completion.assert_called_once()
+        assert "stop" not in mock_completion.call_args.kwargs


### PR DESCRIPTION

#### Reference Issues/PRs

See also #889 (users asking to constrain output for DeepSeek-R1 style models).
No open issue tracks this specific gap; found while reading the model config.

#### What does this implement/fix? Explain your changes.

`GenericAPIModelConfig` exposes a `stop` field, documented as "Custom stop
sequences" and settable from any model config:

```python
# sweagent/agent/models.py
stop: list[str] = []
"""Custom stop sequences"""
```

`stop` is a first-class, OpenAI-standard parameter of `litellm.completion`
(up to 4 sequences at which the provider stops generating). However,
`LiteLLMModel._single_query` builds the completion call without it. It passes
`model`, `messages`, `temperature`, `top_p`, `api_version`, `api_key`,
`fallbacks`, `**completion_kwargs`, `**extra_args`, and `n`, but never `stop`:

```python
response = litellm.completion(
    model=self.config.name,
    messages=messages,
    temperature=...,
    top_p=self.config.top_p,
    api_version=self.config.api_version,
    api_key=self.config.choose_api_key(),
    fallbacks=self.config.fallbacks,
    **completion_kwargs,
    **extra_args,
    n=n,
)
```

`self.config.stop` is read nowhere else in the module, so any stop sequences a
user configures are silently dropped and never reach the provider. That is
surprising for open and local models that rely on stop sequences to terminate
their output.

This forwards `config.stop` through the existing `extra_args` block, and only
when it is non-empty, mirroring exactly how the adjacent optional `api_base`
argument is handled:

```python
if self.config.api_base:
    # Not assigned a default value in litellm, so only pass this if it's set
    extra_args["api_base"] = self.config.api_base
if self.config.stop:
    # Only pass custom stop sequences if configured, so the default behavior is unchanged
    extra_args["stop"] = self.config.stop
```

Because the default is an empty list (falsy), nothing is sent unless the user
opts in, so existing behavior is unchanged.

Files changed:
- `sweagent/agent/models.py`: forward `config.stop` to the completion call when set (+3 lines).
- `tests/test_models.py`: two regression tests: `stop` is forwarded when configured, and omitted when not.

Testing: `pytest tests/test_models.py` passes (6 passed), no Docker or LLM key
needed. Reverting the 3-line fix makes `test_stop_sequences_forwarded` fail
(the forwarded `stop` is `None`), confirming the test catches the regression.
`ruff check` and `ruff format --check` are clean on both files.
