### PR TITLE
fix: map multimodal subset to sb-cli's swe-bench-m

### DIFF
--- a/sweagent/run/hooks/swe_bench_evaluate.py
+++ b/sweagent/run/hooks/swe_bench_evaluate.py
@@ -17,7 +17,10 @@ from sweagent.utils.log import get_logger
 
 
 class SweBenchEvaluate(RunHook):
-    _SUBSET_MAP = {"lite": "swe-bench_lite", "verified": "swe-bench_verified", "multimodal": "swe-bench_multimodal"}
+    # Maps SWEBenchInstances.subset values to the subset identifiers accepted by
+    # sb-cli. sb-cli only supports these three; "full" and "multilingual" have no
+    # sb-cli equivalent and therefore cannot be evaluated this way.
+    _SUBSET_MAP = {"lite": "swe-bench_lite", "verified": "swe-bench_verified", "multimodal": "swe-bench-m"}
 
     def __init__(self, output_dir: Path, subset: str, split: str, continuous_submission_every: int = 0) -> None:
         super().__init__()
@@ -38,6 +41,12 @@ class SweBenchEvaluate(RunHook):
         return f"{self.output_dir.name}_{self._time_suffix}"
 
     def _get_sb_call(self, preds_path: Path, submit_only: bool = False) -> list[str]:
+        if self.subset not in self._SUBSET_MAP:
+            msg = (
+                f"Cannot evaluate subset {self.subset!r} with sb-cli. "
+                f"Supported subsets are: {', '.join(self._SUBSET_MAP)}."
+            )
+            raise ValueError(msg)
         args = [
             "sb-cli",
             "submit",

--- a/tests/test_run_hooks.py
+++ b/tests/test_run_hooks.py
@@ -8,6 +8,7 @@ import pytest
 from sweagent.agent.problem_statement import GithubIssue, TextProblemStatement
 from sweagent.run.hooks.apply_patch import SaveApplyPatchHook
 from sweagent.run.hooks.open_pr import OpenPRConfig, OpenPRHook
+from sweagent.run.hooks.swe_bench_evaluate import SweBenchEvaluate
 from sweagent.types import AgentRunResult
 
 
@@ -127,3 +128,38 @@ def test_save_apply_patch_hook_concurrent_workers_save_to_correct_dirs(tmp_path)
     assert patch_b.exists(), "Patch for instance-B was not saved to its own directory"
     assert patch_a.read_text() == "patch A content"
     assert patch_b.read_text() == "patch B content"
+
+
+@pytest.mark.parametrize(
+    ("subset", "expected"),
+    [
+        ("lite", "swe-bench_lite"),
+        ("verified", "swe-bench_verified"),
+        ("multimodal", "swe-bench-m"),
+    ],
+)
+def test_swe_bench_evaluate_subset_matches_sb_cli(tmp_path, subset, expected):
+    """The subset passed to sb-cli must be one of its accepted values.
+
+    sb-cli's ``Subset`` enum only accepts ``swe-bench_lite``, ``swe-bench_verified``
+    and ``swe-bench-m``. In particular the multimodal dataset is ``swe-bench-m``,
+    not ``swe-bench_multimodal``, so submitting the latter is rejected at the CLI
+    boundary and ``--evaluate=True`` fails on a multimodal run.
+    """
+    hook = SweBenchEvaluate(output_dir=tmp_path, subset=subset, split="dev")
+    call = hook._get_sb_call(tmp_path / "preds.json")
+    # ["sb-cli", "submit", <subset>, <split>, ...]
+    assert call[2] == expected
+
+
+@pytest.mark.parametrize("subset", ["full", "multilingual"])
+def test_swe_bench_evaluate_unsupported_subset_raises_value_error(tmp_path, subset):
+    """Subsets with no sb-cli equivalent must fail with a clear error.
+
+    ``full`` and ``multilingual`` are valid ``SWEBenchInstances.subset`` values for
+    loading instances, but sb-cli cannot evaluate them. Building the call must raise
+    a descriptive ValueError instead of a bare KeyError.
+    """
+    hook = SweBenchEvaluate(output_dir=tmp_path, subset=subset, split="dev")
+    with pytest.raises(ValueError, match=subset):
+        hook._get_sb_call(tmp_path / "preds.json")


### PR DESCRIPTION

#### Reference Issues/PRs

No existing issue. This is a follow-up to #1223 (SWE-agent Multimodal), which
added the `multimodal` subset to `SWEBenchInstances` but did not update the
evaluation hook's subset mapping.

#### What does this implement/fix? Explain your changes.

`SweBenchEvaluate` builds an `sb-cli submit` command whenever a batch run is
started with `--evaluate=True`. It translates the run's `subset` to the subset
identifier that sb-cli expects via `_SUBSET_MAP`
(`sweagent/run/hooks/swe_bench_evaluate.py`):

```python
_SUBSET_MAP = {"lite": "swe-bench_lite", "verified": "swe-bench_verified", "multimodal": "swe-bench_multimodal"}
```

Two problems:

1. **`multimodal` maps to a subset sb-cli rejects.** sb-cli's `Subset` enum only
   accepts `swe-bench_lite`, `swe-bench_verified` and `swe-bench-m`, and its
   `submit` command declares the subset argument with that enum type, so any
   other string is rejected at the CLI boundary. The multimodal dataset is
   `swe-bench-m`, not `swe-bench_multimodal`. As a result, running a multimodal
   batch with `--evaluate=True` always fails when the hook shells out to sb-cli.

2. **`full` and `multilingual` raise a bare `KeyError`.** Both are valid
   `SWEBenchInstances.subset` values for loading instances, but neither is a key
   in `_SUBSET_MAP`, so `_get_sb_call` fails with an unhelpful
   `KeyError: 'full'` / `KeyError: 'multilingual'` instead of a clear message.

Both symptoms share one root cause: `_SUBSET_MAP` drifted out of sync with
sb-cli's accepted subsets when the multimodal subset was introduced in #1223.

**Changes** (`sweagent/run/hooks/swe_bench_evaluate.py`):

- Map `"multimodal"` to `"swe-bench-m"` so multimodal evaluation submits a
  subset sb-cli accepts.
- Guard `_get_sb_call`: if the subset has no sb-cli equivalent (`full`,
  `multilingual`), raise a descriptive `ValueError` naming the supported
  subsets instead of a bare `KeyError`. This mirrors the existing "Unsupported
  subset" `ValueError` in `batch_instances.py`.

**Tests** (`tests/test_run_hooks.py`): parametrized regression tests that assert
the subset passed to sb-cli for `lite`/`verified`/`multimodal`, and that
`full`/`multilingual` raise `ValueError`. Verified failing before the fix and
passing after.

```
pytest tests/test_run_hooks.py -k swe_bench_evaluate   # 5 passed
```
