### PR TITLE
fix(log): guard shared logger globals writers with _LOG_LOCK

### DIFF
--- a/sweagent/utils/log.py
+++ b/sweagent/utils/log.py
@@ -75,8 +75,8 @@ def get_logger(name: str, *, emoji: str = "") -> logging.Logger:
     logger.setLevel(logging.TRACE)  # type: ignore
     logger.addHandler(handler)
     logger.propagate = False
-    _SET_UP_LOGGERS.add(name)
     with _LOG_LOCK:
+        _SET_UP_LOGGERS.add(name)
         for handler in _ADDITIONAL_HANDLERS.values():
             my_filter = getattr(handler, "my_filter", None)
             if my_filter is None:
@@ -114,8 +114,12 @@ def add_file_handler(
     formatter = logging.Formatter("%(asctime)s - %(levelname)s - %(name)s - %(message)s")
     handler.setFormatter(formatter)
     handler.setLevel(_interpret_level(level))
+    handler.my_filter = filter  # type: ignore
+    if not id_:
+        id_ = str(uuid.uuid4())
     with _LOG_LOCK:
         # Lock because other thread might be modifying the _SET_UP_LOGGERS set
+        # or iterating _ADDITIONAL_HANDLERS.
         for name in _SET_UP_LOGGERS:
             if filter is not None:
                 if isinstance(filter, str) and filter not in name:
@@ -124,18 +128,16 @@ def add_file_handler(
                     continue
             logger = logging.getLogger(name)
             logger.addHandler(handler)
-    handler.my_filter = filter  # type: ignore
-    if not id_:
-        id_ = str(uuid.uuid4())
-    _ADDITIONAL_HANDLERS[id_] = handler
+        _ADDITIONAL_HANDLERS[id_] = handler
     return id_
 
 
 def remove_file_handler(id_: str) -> None:
     """Remove a file handler by its id."""
-    handler = _ADDITIONAL_HANDLERS.pop(id_)
     with _LOG_LOCK:
         # Lock because other thread might be modifying the _SET_UP_LOGGERS set
+        # or iterating _ADDITIONAL_HANDLERS.
+        handler = _ADDITIONAL_HANDLERS.pop(id_)
         for log_name in _SET_UP_LOGGERS:
             logger = logging.getLogger(log_name)
             logger.removeHandler(handler)

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import logging
+import sys
+import threading
+from concurrent.futures import ThreadPoolExecutor
+
+import sweagent.utils.log as log_module
+from sweagent.utils.log import add_file_handler, get_logger, remove_file_handler
+
+
+def test_get_logger_thread_safe_with_concurrent_file_handlers(tmp_path):
+    """Regression test for #981: get_logger must not crash with
+    'RuntimeError: dictionary/set changed size during iteration' when other
+    threads add or remove file handlers at the same time.
+
+    #981 was reported as a crash inside get_logger while iterating
+    ``_ADDITIONAL_HANDLERS`` and was closed by #993. #993 (and the earlier
+    handler-locking commit) only wrapped the *readers* that iterate the shared
+    globals ``_SET_UP_LOGGERS`` and ``_ADDITIONAL_HANDLERS`` in ``_LOG_LOCK``.
+    The *writers* were left unlocked: get_logger did ``_SET_UP_LOGGERS.add(name)``
+    outside the lock, and add_file_handler / remove_file_handler mutated
+    ``_ADDITIONAL_HANDLERS`` outside the lock. Holding the lock only for the
+    reader gives no protection when another thread mutates the same container
+    without the lock, so the crash can still happen under run-batch with
+    num_workers > 1.
+
+    This test hammers get_logger (writes ``_SET_UP_LOGGERS``, reads
+    ``_ADDITIONAL_HANDLERS``) against add_file_handler / remove_file_handler
+    (read ``_SET_UP_LOGGERS``, write ``_ADDITIONAL_HANDLERS``) from many threads
+    and fails if any thread raises.
+    """
+    errors: list[Exception] = []
+    stop = threading.Event()
+    name_prefix = "test-log-race-"
+
+    # Pre-populate the shared globals so the locked reader loops iterate large
+    # containers. This widens the window in which an unlocked writer in another
+    # thread can mutate the same container mid-iteration, making the race
+    # reproducible instead of relying on a lucky interleaving.
+    preexisting_logger_names = [f"{name_prefix}preexisting-{i}" for i in range(2000)]
+    preexisting_handler_ids = [f"{name_prefix}preexisting-handler-{i}" for i in range(500)]
+    for name in preexisting_logger_names:
+        log_module._SET_UP_LOGGERS.add(name)
+    for handler_id in preexisting_handler_ids:
+        log_module._ADDITIONAL_HANDLERS[handler_id] = logging.NullHandler()
+
+    # Encourage frequent thread switches so the race surfaces quickly.
+    old_switch_interval = sys.getswitchinterval()
+    sys.setswitchinterval(1e-6)
+
+    # get_logger short-circuits (never reaching the racy writer) if the logger
+    # already ``hasHandlers()``. pytest attaches capture handlers to the root
+    # logger, which would make every fresh logger report handlers via the root,
+    # so temporarily detach them to exercise the real production code path.
+    root_logger = logging.getLogger()
+    saved_root_handlers = root_logger.handlers[:]
+    root_logger.handlers.clear()
+
+    def make_loggers(worker_id: int) -> None:
+        try:
+            i = 0
+            while not stop.is_set():
+                get_logger(f"{name_prefix}{worker_id}-{i}")
+                i += 1
+        except Exception as e:
+            errors.append(e)
+            stop.set()
+
+    def churn_file_handlers(worker_id: int) -> None:
+        try:
+            i = 0
+            while not stop.is_set():
+                id_ = add_file_handler(tmp_path / f"handler-{worker_id}-{i}.log")
+                remove_file_handler(id_)
+                i += 1
+        except Exception as e:
+            errors.append(e)
+            stop.set()
+
+    timer = threading.Timer(2.0, stop.set)
+    timer.start()
+    try:
+        with ThreadPoolExecutor(max_workers=12) as pool:
+            futures = [pool.submit(make_loggers, w) for w in range(6)]
+            futures += [pool.submit(churn_file_handlers, w) for w in range(6)]
+            for future in futures:
+                future.result()
+    finally:
+        timer.cancel()
+        stop.set()
+        sys.setswitchinterval(old_switch_interval)
+        root_logger.handlers[:] = saved_root_handlers
+        # Clean up the module-level global state we polluted so we don't leak
+        # loggers/handlers into other tests.
+        for name in [name for name in list(log_module._SET_UP_LOGGERS) if name.startswith(name_prefix)]:
+            logger = logging.getLogger(name)
+            for handler in list(logger.handlers):
+                logger.removeHandler(handler)
+            log_module._SET_UP_LOGGERS.discard(name)
+        for handler_id in preexisting_handler_ids:
+            log_module._ADDITIONAL_HANDLERS.pop(handler_id, None)
+
+    assert not errors, f"get_logger raced with file-handler mutation: {errors[0]!r}"


### PR DESCRIPTION

<!-- follows .github/PULL_REQUEST_TEMPLATE.md -->

#### Reference Issues/PRs

Recurrence of #981 (`Race condition: get_logger and modifying _ADDITIONAL_HANDLERS`).
That issue was closed by #993, but the fix there was incomplete (see below), so the
same crash can still happen. Not using a `Fixes` keyword because #981 is already
closed.

#### What does this implement/fix? Explain your changes.

**The bug.** Under `run-batch` with `num_workers > 1`, `get_logger` can still crash with

```
RuntimeError: dictionary changed size during iteration
```

(or the `set` variant), which is the exact failure reported in #981.

`sweagent/utils/log.py` keeps two module-level globals that are shared across threads:
`_SET_UP_LOGGERS` (a `set`) and `_ADDITIONAL_HANDLERS` (a `dict`). `_LOG_LOCK` exists
to serialize access to them. #993 (and the earlier handler-locking commit) wrapped the
**readers** that iterate these containers in `with _LOG_LOCK:`, but left the **writers**
outside the lock:

- `get_logger` iterated `_ADDITIONAL_HANDLERS` under the lock, but called
  `_SET_UP_LOGGERS.add(name)` *outside* it.
- `add_file_handler` iterated `_SET_UP_LOGGERS` under the lock, but did
  `_ADDITIONAL_HANDLERS[id_] = handler` *outside* it.
- `remove_file_handler` iterated `_SET_UP_LOGGERS` under the lock, but did
  `_ADDITIONAL_HANDLERS.pop(id_)` *outside* it.

Holding the lock only while you read a container gives no protection when another
thread mutates that same container without holding the lock. So thread A iterating
`_ADDITIONAL_HANDLERS.values()` under the lock in `get_logger` can still be interrupted
by thread B doing an unlocked `_ADDITIONAL_HANDLERS[...] = ...` in `add_file_handler`,
and Python raises `dictionary changed size during iteration` mid-iteration. The
symmetric case holds for `_SET_UP_LOGGERS` (`get_logger`'s unlocked `.add` versus the
locked `for name in _SET_UP_LOGGERS` in `add_file_handler`/`remove_file_handler`). The
comments already said `Lock because other thread might be modifying the
_SET_UP_LOGGERS set`, but the code that actually modifies it did not take the lock, so
the invariant was not enforced.

This is reachable in normal use: `run_batch` runs `run_instance` for each instance in a
`ThreadPoolExecutor(max_workers=num_workers)`, and those worker threads both create
loggers (`get_logger`) and add/remove per-run file handlers concurrently.

**The fix.** Move each of the three writers inside the existing `with _LOG_LOCK:` block
so every access to `_SET_UP_LOGGERS` and `_ADDITIONAL_HANDLERS` is serialized:

- `get_logger`: `_SET_UP_LOGGERS.add(name)` now runs under the lock.
- `add_file_handler`: `_ADDITIONAL_HANDLERS[id_] = handler` now runs under the lock,
  atomically with adding the handler to the already-set-up loggers. The purely local
  setup (`handler.my_filter = filter` and the `id_` default) is computed before the lock
  so the critical section stays small; a side benefit is that `my_filter` is now always
  set before the handler becomes visible in `_ADDITIONAL_HANDLERS`, so `get_logger` can
  no longer observe a registered handler that is missing its `my_filter` attribute.
- `remove_file_handler`: `_ADDITIONAL_HANDLERS.pop(id_)` now runs under the lock.

`_LOG_LOCK` is a plain (non-reentrant) `threading.Lock`, and nothing inside these blocks
re-acquires it, so there is no deadlock. The lock/`logging` ordering is unchanged: the
readers already called `logging.getLogger(...)`/`logger.addHandler(...)` under
`_LOG_LOCK`. There is no functional change beyond the added serialization.

**Files changed**

- `sweagent/utils/log.py`: moved the three writers inside `_LOG_LOCK`; updated the two
  comments to note the lock also guards `_ADDITIONAL_HANDLERS`.
- `tests/test_log.py` (new): a regression test that hammers `get_logger` against
  `add_file_handler`/`remove_file_handler` from 12 threads and fails if any thread
  raises. To make the race reproducible rather than luck-based it pre-populates the
  globals (so the locked reader loops iterate large containers, widening the window) and
  lowers `sys.setswitchinterval`; it also temporarily detaches pytest's root-logger
  capture handlers so `get_logger` does not short-circuit at `hasHandlers()` and actually
  reaches the racy code path. All global/state changes (switch interval, root handlers,
  and every entry it added to the globals) are restored in `finally`. On `main` this test
  fails with the `RuntimeError: ... changed size during iteration`; with the fix it
  passes.

**How I verified**

- `pytest tests/test_log.py` passes with the fix and fails on unmodified `main`
  (reproducing both the `set` and the `dict` "changed size during iteration" errors).
- No regressions in the Docker-free unit subset (`tests/test_log.py`,
  `tests/test_models.py`, `tests/test_utils.py`, `tests/test_parsing.py`, and the
  concurrent-workers run-hook test).
- `ruff check` and `ruff format --check` are clean on both files.
