### PR TITLE
fix(run): write reusable config snapshots

### DIFF
--- a/sweagent/run/run_batch.py
+++ b/sweagent/run/run_batch.py
@@ -197,7 +197,7 @@ class RunBatch:
         load_environment_variables(config.env_var_path)
         config.set_default_output_dir()
         config.output_dir.mkdir(parents=True, exist_ok=True)
-        (config.output_dir / "run_batch.config.yaml").write_text(yaml.dump(config.model_dump_json(), indent=2))
+        (config.output_dir / "run_batch.config.yaml").write_text(yaml.dump(config.model_dump(mode="json"), indent=2))
         logger = get_logger("run", emoji="🏃")
         logger.debug("Loading instances from %s", f"{config.instances!r}")
         instances = config.instances.get_instance_configs()
@@ -341,7 +341,7 @@ class RunBatch:
             env=instance.env,
         )
         (output_dir / f"{instance.problem_statement.id}.config.yaml").write_text(
-            yaml.dump(single_run_replay_config.model_dump_json(), indent=2)
+            yaml.dump(single_run_replay_config.model_dump(mode="json"), indent=2)
         )
         agent.replay_config = single_run_replay_config  # type: ignore[attr-defined]
         agent.add_hook(SetStatusAgentHook(instance.problem_statement.id, self._progress_manager.update_instance_status))

--- a/sweagent/run/run_single.py
+++ b/sweagent/run/run_single.py
@@ -194,7 +194,9 @@ class RunSingle:
         output_dir = self.output_dir / self.problem_statement.id
         output_dir.mkdir(parents=True, exist_ok=True)
         if self.agent.replay_config is not None:  # type: ignore[attr-defined]
-            (output_dir / "config.yaml").write_text(yaml.dump(self.agent.replay_config.model_dump_json(), indent=2))  # type: ignore[attr-defined]
+            (output_dir / "config.yaml").write_text(
+                yaml.dump(self.agent.replay_config.model_dump(mode="json"), indent=2)  # type: ignore[attr-defined]
+            )
         result = self.agent.run(
             problem_statement=self.problem_statement,
             env=self.env,

--- a/tests/test_run_batch.py
+++ b/tests/test_run_batch.py
@@ -1,8 +1,68 @@
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
+from swerex.deployment.config import DummyDeploymentConfig
 
+from sweagent.agent.agents import DefaultAgentConfig
+from sweagent.agent.models import InstantEmptySubmitModelConfig
+from sweagent.run.batch_instances import InstancesFromFile
+from sweagent.run.common import BasicCLI
 from sweagent.run.run import main
+from sweagent.run.run_batch import RunBatch, RunBatchConfig
+from sweagent.run.run_single import RunSingleConfig
+
+
+def test_run_batch_config_snapshot_is_reusable(test_data_sources_path: Path, tmp_path: Path):
+    config = RunBatchConfig(
+        instances=InstancesFromFile(
+            path=test_data_sources_path / "simple_instances.yaml",
+            deployment=DummyDeploymentConfig(),
+        ),
+        agent=DefaultAgentConfig(model=InstantEmptySubmitModelConfig()),
+        output_dir=tmp_path,
+    )
+
+    RunBatch.from_config(config)
+
+    snapshot = tmp_path / "run_batch.config.yaml"
+    loaded = BasicCLI(RunBatchConfig).get_config(["--config", str(snapshot)])
+    assert loaded.model_dump(mode="json") == config.model_dump(mode="json")
+
+
+def test_run_batch_instance_config_snapshot_is_reusable(
+    test_data_sources_path: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    config = RunBatchConfig(
+        instances=InstancesFromFile(
+            path=test_data_sources_path / "simple_instances.yaml",
+            deployment=DummyDeploymentConfig(),
+        ),
+        agent=DefaultAgentConfig(model=InstantEmptySubmitModelConfig()),
+        output_dir=tmp_path,
+    )
+    run = RunBatch.from_config(config)
+    instance = run.instances[0]
+    expected = RunSingleConfig(
+        agent=config.agent.model_copy(deep=True, update={"name": instance.problem_statement.id}),
+        problem_statement=instance.problem_statement.model_copy(deep=True),
+        env=instance.env.model_copy(deep=True),
+    )
+    monkeypatch.setattr("sweagent.run.run_batch.get_agent_from_config", lambda config: MagicMock())
+    monkeypatch.setattr(run._progress_manager, "update_instance_status", lambda *args: None)
+
+    def stop_before_environment_start(config):
+        msg = "stop before environment start"
+        raise RuntimeError(msg)
+
+    monkeypatch.setattr("sweagent.run.run_batch.SWEEnv.from_config", stop_before_environment_start)
+
+    with pytest.raises(RuntimeError, match="stop before environment start"):
+        run._run_instance(instance)
+
+    snapshot = tmp_path / instance.problem_statement.id / f"{instance.problem_statement.id}.config.yaml"
+    loaded = BasicCLI(RunSingleConfig).get_config(["--config", str(snapshot)])
+    assert loaded.model_dump(mode="json") == expected.model_dump(mode="json")
 
 
 @pytest.mark.slow

--- a/tests/test_run_single.py
+++ b/tests/test_run_single.py
@@ -1,23 +1,50 @@
 from __future__ import annotations
 
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
+from swerex.deployment.config import DummyDeploymentConfig
 
 from sweagent import CONFIG_DIR, TOOLS_DIR
 from sweagent.agent.agents import DefaultAgentConfig
 from sweagent.agent.models import InstantEmptySubmitModelConfig
+from sweagent.agent.problem_statement import TextProblemStatement
 from sweagent.environment.swe_env import EnvironmentConfig
 from sweagent.run.common import BasicCLI
 from sweagent.run.hooks.abstract import RunHook
 from sweagent.run.run_single import RunSingle, RunSingleConfig
 from sweagent.tools.bundle import Bundle
+from sweagent.types import AgentRunResult
 
 
 class RaisesExceptionHook(RunHook):
     def on_instance_start(self, *args, **kwargs):
         msg = "test exception"
         raise ValueError(msg)
+
+
+def test_run_single_config_snapshot_is_reusable(tmp_path: Path):
+    config = RunSingleConfig(
+        env=EnvironmentConfig(deployment=DummyDeploymentConfig()),
+        agent=DefaultAgentConfig(model=InstantEmptySubmitModelConfig()),
+        problem_statement=TextProblemStatement(text="Test issue", id="test-instance"),
+        output_dir=tmp_path,
+    )
+    agent = MagicMock()
+    agent.replay_config = config
+    agent.run.return_value = AgentRunResult(info={"submission": None, "exit_status": "submitted"}, trajectory=[])
+
+    RunSingle(
+        env=MagicMock(),
+        agent=agent,
+        problem_statement=config.problem_statement,
+        output_dir=tmp_path,
+    ).run()
+
+    snapshot = tmp_path / config.problem_statement.id / "config.yaml"
+    loaded = BasicCLI(RunSingleConfig).get_config(["--config", str(snapshot)])
+    assert loaded.model_dump(mode="json") == config.model_dump(mode="json")
 
 
 @pytest.mark.slow


### PR DESCRIPTION
#### Reference Issues/PRs

No linked issue.

#### What does this implement/fix? Explain your changes.

Generated single-run, batch-run, and per-instance config snapshots were YAML scalars containing JSON text. Reusing those snapshots with `--config`, as documented, passed a string into nested config merging and raised `AttributeError: 'str' object has no attribute 'items'`.

This changes all three snapshot writers to dump JSON-compatible model data as YAML mappings. It also adds offline regression tests that load each generated snapshot through `BasicCLI` and verify that it reconstructs the original config.

Tests:

- `uv run --no-sync pytest tests/test_run_single.py tests/test_run_batch.py -m 'not slow' -q` (5 passed, 11 deselected)
- `uv run --no-sync ruff check sweagent/run/run_single.py sweagent/run/run_batch.py tests/test_run_single.py tests/test_run_batch.py`
- `uv run --no-sync ruff format --check sweagent/run/run_single.py sweagent/run/run_batch.py tests/test_run_single.py tests/test_run_batch.py`
- `uv run --no-sync pre-commit run --files sweagent/run/run_single.py sweagent/run/run_batch.py tests/test_run_single.py tests/test_run_batch.py`

DCO: the commit includes a `Signed-off-by` trailer.
