### PR TITLE
fix(replay): preserve environment startup configuration

### DIFF
--- a/sweagent/run/run_replay.py
+++ b/sweagent/run/run_replay.py
@@ -174,7 +174,9 @@ class RunReplay:
         return SWEEnv(
             deployment=self.deployment,
             repo=self.config.env.repo,
-            post_startup_commands=[],
+            post_startup_commands=self.config.env.post_startup_commands,
+            post_startup_command_timeout=self.config.env.post_startup_command_timeout,
+            name=self.config.env.name,
         )
 
     def _get_agent(self) -> DefaultAgent:

--- a/tests/test_run_replay.py
+++ b/tests/test_run_replay.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
+import json
 import subprocess
+from unittest.mock import MagicMock, patch
 
 import pytest
+from swerex.deployment.abstract import AbstractDeployment
 from swerex.deployment.config import DockerDeploymentConfig
 
 from sweagent.run.run_replay import RunReplay, RunReplayConfig
@@ -20,6 +23,31 @@ def rr_config(swe_agent_test_repo_traj, tmp_path, swe_agent_test_repo_clone):
 def test_replay(rr_config):
     rr = RunReplay.from_config(rr_config, _catch_errors=False, _require_zero_exit_code=True)
     rr.main()
+
+
+def test_replay_preserves_environment_config(swe_agent_test_repo_traj, tmp_path):
+    traj_data = json.loads(swe_agent_test_repo_traj.read_text())
+    traj_data["replay_config"]["env"].update(
+        post_startup_commands=["echo setup"],
+        post_startup_command_timeout=123,
+        name="replay",
+    )
+    traj_path = tmp_path / "replay.traj"
+    traj_path.write_text(json.dumps(traj_data))
+
+    deployment = MagicMock(spec=AbstractDeployment)
+    rr = RunReplay(traj_path=traj_path, deployment=deployment, output_dir=tmp_path)
+
+    with patch("sweagent.run.run_replay.SWEEnv") as swe_env:
+        rr._get_env()
+
+    swe_env.assert_called_once_with(
+        deployment=deployment,
+        repo=rr.config.env.repo,
+        post_startup_commands=["echo setup"],
+        post_startup_command_timeout=123,
+        name="replay",
+    )
 
 
 def test_run_cli_help():


### PR DESCRIPTION
#### Reference Issues/PRs

None. This is a standalone replay correctness fix found while reviewing the trajectory replay path.

#### What does this implement/fix? Explain your changes.

`RunReplay` parses the environment configuration recorded in a trajectory, but `_get_env()` previously reconstructed `SWEEnv` with `post_startup_commands=[]` and left the startup timeout and environment name at their defaults. As a result, replay skipped any recorded environment setup commands and could execute against a different environment than the original run, causing failures or divergent results.

This forwards `post_startup_commands`, `post_startup_command_timeout`, and `name` from the recorded environment configuration while retaining the deployment selected for the replay. This matches the configuration handling in `SWEEnv.from_config()`.

The regression test builds a replay configuration with a startup command, custom timeout, and environment name, then verifies that `_get_env()` passes all three values to `SWEEnv` together with the replay deployment.

Tests:
- `uv run --no-sync pytest -q tests/test_run_replay.py::test_replay_preserves_environment_config`
- `uv run --no-sync pre-commit run --files sweagent/run/run_replay.py tests/test_run_replay.py`
