### PR TITLE
fix: honor trajectory directory in all run modes

### DIFF
--- a/sweagent/run/run_replay.py
+++ b/sweagent/run/run_replay.py
@@ -34,6 +34,7 @@ from swerex.deployment.abstract import AbstractDeployment
 from swerex.deployment.config import DeploymentConfig, get_deployment
 from typing_extensions import Self
 
+from sweagent import TRAJECTORY_DIR
 from sweagent.agent.agents import DefaultAgent
 from sweagent.agent.models import ReplayModelConfig
 from sweagent.environment.swe_env import SWEEnv
@@ -59,7 +60,7 @@ class RunReplayConfig(BaseSettings, cli_implicit_flags=False):
     def model_post_init(self, __context: Any) -> None:
         if self.output_dir == Path("DEFAULT"):
             user_id = getuser()
-            self.output_dir = Path.cwd() / "trajectories" / user_id / f"replay___{self.traj_path.stem}"
+            self.output_dir = TRAJECTORY_DIR / user_id / f"replay___{self.traj_path.stem}"
         self.output_dir.mkdir(parents=True, exist_ok=True)
 
 

--- a/sweagent/run/run_single.py
+++ b/sweagent/run/run_single.py
@@ -36,6 +36,7 @@ import yaml
 from pydantic import BaseModel, ConfigDict, Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
+from sweagent import TRAJECTORY_DIR
 from sweagent.agent.agents import AbstractAgent, AgentConfig, get_agent_from_config
 from sweagent.agent.problem_statement import (
     EmptyProblemStatement,
@@ -76,7 +77,7 @@ def _get_default_output_dir(output_dir: Path, problem_statement: ProblemStatemen
         config_file = getattr(agent, "_config_files", ["no_config"])[0]
         if isinstance(config_file, Path):
             config_file = config_file.stem
-        return Path.cwd() / "trajectories" / user_id / f"{config_file}__{model_id}___{problem_id}"
+        return TRAJECTORY_DIR / user_id / f"{config_file}__{model_id}___{problem_id}"
     return output_dir
 
 

--- a/tests/test_run_replay.py
+++ b/tests/test_run_replay.py
@@ -8,6 +8,15 @@ from swerex.deployment.config import DockerDeploymentConfig
 from sweagent.run.run_replay import RunReplay, RunReplayConfig
 
 
+def test_default_output_dir_uses_trajectory_dir(monkeypatch, tmp_path):
+    monkeypatch.setattr("sweagent.run.run_replay.TRAJECTORY_DIR", tmp_path)
+    monkeypatch.setattr("sweagent.run.run_replay.getuser", lambda: "test-user")
+
+    config = RunReplayConfig(traj_path=tmp_path / "test.traj")
+
+    assert config.output_dir == tmp_path / "test-user" / "replay___test"
+
+
 @pytest.fixture
 def rr_config(swe_agent_test_repo_traj, tmp_path, swe_agent_test_repo_clone):
     return RunReplayConfig(

--- a/tests/test_run_single.py
+++ b/tests/test_run_single.py
@@ -7,6 +7,7 @@ import pytest
 from sweagent import CONFIG_DIR, TOOLS_DIR
 from sweagent.agent.agents import DefaultAgentConfig
 from sweagent.agent.models import InstantEmptySubmitModelConfig
+from sweagent.agent.problem_statement import EmptyProblemStatement
 from sweagent.environment.swe_env import EnvironmentConfig
 from sweagent.run.common import BasicCLI
 from sweagent.run.hooks.abstract import RunHook
@@ -18,6 +19,20 @@ class RaisesExceptionHook(RunHook):
     def on_instance_start(self, *args, **kwargs):
         msg = "test exception"
         raise ValueError(msg)
+
+
+def test_default_output_dir_uses_trajectory_dir(monkeypatch, tmp_path):
+    monkeypatch.setattr("sweagent.run.run_single.TRAJECTORY_DIR", tmp_path)
+    monkeypatch.setattr("sweagent.run.run_single.getpass.getuser", lambda: "test-user")
+    model = InstantEmptySubmitModelConfig()
+    config = RunSingleConfig(
+        agent=DefaultAgentConfig(model=model),
+        problem_statement=EmptyProblemStatement(id="test-instance"),
+    )
+
+    config.set_default_output_dir()
+
+    assert config.output_dir == tmp_path / "test-user" / f"no_config__{model.id}___test-instance"
 
 
 @pytest.mark.slow


### PR DESCRIPTION
#### Reference Issues/PRs

Follow-up to #1054, which made batch runs use the configured trajectory directory.

#### What does this implement/fix? Explain your changes.

`SWE_AGENT_TRAJECTORY_DIR` defines the shared `TRAJECTORY_DIR`, but single runs and replays previously rebuilt their default output paths from the current working directory. As a result, configuring the trajectory root affected batch runs while these two modes continued writing under `./trajectories`, splitting outputs across different directories.

This changes the single-run and replay defaults to use `TRAJECTORY_DIR`, matching batch-run behavior. Explicit `output_dir` values and the existing per-user and per-run path names remain unchanged.

The regression tests replace the shared trajectory root and verify that both default output paths are derived from it.

Tests:
- `uv run --no-sync pytest -q tests/test_run_single.py::test_default_output_dir_uses_trajectory_dir tests/test_run_replay.py::test_default_output_dir_uses_trajectory_dir`
- `uv run --no-sync ruff check sweagent/run/run_single.py sweagent/run/run_replay.py tests/test_run_single.py tests/test_run_replay.py`
- `uv run --no-sync ruff format --check sweagent/run/run_single.py sweagent/run/run_replay.py tests/test_run_single.py tests/test_run_replay.py`
