### PR TITLE
fix: 0-based line index in WindowedFile.replace

### DIFF
--- a/tests/tools/test_default_utils.py
+++ b/tests/tools/test_default_utils.py
@@ -151,3 +151,11 @@ def test_print_window_new_file(with_tmp_env_file, capsys):
     print(captured.out)
     expected = _DEFAULT_WINDOW_OUTPUT_NEW_FILE.format(path=wfile.path.resolve())
     assert captured.out == expected
+
+
+def test_windowed_file_replace_line_index(with_tmp_env_file):
+    content = "aaa\nbbb\nccc\n"
+    wfile = create_test_file_with_content(with_tmp_env_file, content)
+    info = wfile.replace("bbb", "BBB")
+    assert info.first_replaced_line == 1
+    assert wfile.find_all_occurrences("BBB") == [1]

--- a/tools/windowed/lib/windowed_file.py
+++ b/tools/windowed/lib/windowed_file.py
@@ -244,7 +244,8 @@ class WindowedFile:
                 print(f"Error: Text not found: {search}")
                 exit(1)
             raise TextNotFound
-        replace_start_line = len(self.text[: indices[0]].split("\n"))
+        # 0-based, matching replace_in_window / find_all_occurrences
+        replace_start_line = len(self.text[: indices[0]].split("\n")) - 1
         new_text = self.text.replace(search, replace)
         self.text = new_text
         if reset_first_line == "keep":


### PR DESCRIPTION
## Summary
- `replace()` used 1-based line math; `replace_in_window` / `find_all_occurrences` are 0-based.
- `goto` after whole-file replace landed one line too low.

## Test plan
- [x] Local assert: replace `"bbb"` in `aaa\nbbb\nccc\n` → `first_replaced_line == 1`
- [ ] CI pytest `tests/tools/test_default_utils.py`

Made with [Cursor](https://cursor.com)