### PR TITLE
fix: 1-based flake8 windows for windowed edits

### DIFF
--- a/tools/windowed_edit_replace/bin/edit
+++ b/tools/windowed_edit_replace/bin/edit
@@ -129,10 +129,11 @@ def main(search: str, replace: str, replace_all: bool):
     post_edit_lint = flake8(wf.path)
 
     if not replace_all:
-        # Try to filter out pre-existing errors
+        # Try to filter out pre-existing errors (flake8 lines are 1-based)
+        start = replacement_info.first_replaced_line + 1
         replacement_window = (
-            replacement_info.first_replaced_line,
-            replacement_info.first_replaced_line + replacement_info.n_search_lines - 1,
+            start,
+            start + replacement_info.n_search_lines - 1,
         )
         # print(f"{replacement_info=}")
         # print(f"{replacement_window=}")

--- a/tools/windowed_edit_rewrite/bin/edit
+++ b/tools/windowed_edit_rewrite/bin/edit
@@ -49,9 +49,10 @@ def main(replace: str):
     wf.set_window_text(replace)
     post_edit_lint = flake8(wf.path)
 
+    # flake8 lines are 1-based; WindowedFile.line_range is 0-based
     replacement_window = (
-        start_line,
-        end_line,
+        start_line + 1,
+        end_line + 1,
     )
     new_flake8_output = format_flake8_output(
         post_edit_lint,


### PR DESCRIPTION
## Summary
- Lint filter passed 0-based WindowedFile lines into flake8 windows.
- Match `edit_anthropic` (+1) so pre-existing errors on the edit line are dropped correctly.

## Test plan
- [ ] CI pytest

Made with [Cursor](https://cursor.com)