### PR TITLE
Add launcher-side trajectory save hook

### DIFF
--- a/sweagent/run/hooks/trajectory.py
+++ b/sweagent/run/hooks/trajectory.py
@@ -1,0 +1,37 @@
+import json
+import threading
+from pathlib import Path
+
+from sweagent.agent.problem_statement import ProblemStatement, ProblemStatementConfig
+from sweagent.environment.swe_env import SWEEnv
+from sweagent.run.hooks.abstract import RunHook
+from sweagent.types import AgentRunResult
+from sweagent.utils.log import get_logger
+
+
+class SaveTrajectoryHook(RunHook):
+    """Save completed trajectories to the launcher-side output directory."""
+
+    def __init__(self):
+        self.logger = get_logger("swea-save_trajectory")
+        # A single hook instance can be shared by multiple batch workers.
+        self._local = threading.local()
+
+    def on_init(self, *, run):
+        self._output_dir = Path(run.output_dir)
+
+    def on_instance_start(
+        self, *, index: int, env: SWEEnv, problem_statement: ProblemStatement | ProblemStatementConfig
+    ):
+        self._local.problem_statement = problem_statement
+
+    def on_instance_completed(self, *, result: AgentRunResult):
+        instance_id = self._local.problem_statement.id
+        trajectory_output_dir = self._output_dir / instance_id
+        trajectory_output_dir.mkdir(exist_ok=True, parents=True)
+        trajectory_output_file = trajectory_output_dir / f"{instance_id}.traj"
+        trajectory_output_file.write_text(
+            json.dumps(result.model_dump(mode="json"), indent=2),
+            encoding="utf-8",
+        )
+        self.logger.info("Saved trajectory to %s", trajectory_output_file)

--- a/sweagent/run/run_batch.py
+++ b/sweagent/run/run_batch.py
@@ -58,6 +58,7 @@ from sweagent.run.batch_instances import BatchInstance, BatchInstanceSourceConfi
 from sweagent.run.common import BasicCLI, ConfigHelper, save_predictions
 from sweagent.run.hooks.abstract import CombinedRunHooks, RunHook
 from sweagent.run.hooks.apply_patch import SaveApplyPatchHook
+from sweagent.run.hooks.trajectory import SaveTrajectoryHook
 from sweagent.run.merge_predictions import merge_predictions
 from sweagent.run.run_single import RunSingleConfig
 from sweagent.types import AgentRunResult
@@ -177,7 +178,7 @@ class RunBatch:
         self._chooks = CombinedRunHooks()
         self._redo_existing = redo_existing
         self._num_workers = min(num_workers, len(instances))
-        for hook in hooks or [SaveApplyPatchHook(show_success_message=False)]:
+        for hook in hooks or [SaveApplyPatchHook(show_success_message=False), SaveTrajectoryHook()]:
             self.add_hook(hook)
         self._progress_manager = RunBatchProgressManager(
             num_instances=len(instances), yaml_report_path=output_dir / "run_batch_exit_statuses.yaml"

--- a/sweagent/run/run_single.py
+++ b/sweagent/run/run_single.py
@@ -48,6 +48,7 @@ from sweagent.run.common import BasicCLI, ConfigHelper, save_predictions
 from sweagent.run.hooks.abstract import CombinedRunHooks, RunHook
 from sweagent.run.hooks.apply_patch import SaveApplyPatchHook
 from sweagent.run.hooks.open_pr import OpenPRConfig, OpenPRHook
+from sweagent.run.hooks.trajectory import SaveTrajectoryHook
 from sweagent.utils.config import load_environment_variables
 from sweagent.utils.log import add_file_handler, get_logger
 
@@ -176,6 +177,7 @@ class RunSingle:
             actions=config.actions,
         )
         self.add_hook(SaveApplyPatchHook(apply_patch_locally=config.actions.apply_patch_locally))
+        self.add_hook(SaveTrajectoryHook())
         if config.actions.open_pr:
             self.logger.debug("Adding OpenPRHook")
             self.add_hook(OpenPRHook(config.actions.pr_config))

--- a/tests/test_run_hooks.py
+++ b/tests/test_run_hooks.py
@@ -1,3 +1,4 @@
+import json
 import os
 import threading
 from concurrent.futures import ThreadPoolExecutor
@@ -9,6 +10,7 @@ from sweagent.agent.problem_statement import GithubIssue, TextProblemStatement
 from sweagent.run.hooks.apply_patch import SaveApplyPatchHook
 from sweagent.run.hooks.open_pr import OpenPRConfig, OpenPRHook
 from sweagent.run.hooks.swe_bench_evaluate import SweBenchEvaluate
+from sweagent.run.hooks.trajectory import SaveTrajectoryHook
 from sweagent.types import AgentRunResult
 
 
@@ -128,6 +130,57 @@ def test_save_apply_patch_hook_concurrent_workers_save_to_correct_dirs(tmp_path)
     assert patch_b.exists(), "Patch for instance-B was not saved to its own directory"
     assert patch_a.read_text() == "patch A content"
     assert patch_b.read_text() == "patch B content"
+
+
+def test_save_trajectory_hook_saves_result_to_instance_dir(tmp_path):
+    hook = SaveTrajectoryHook()
+    hook._output_dir = tmp_path
+
+    ps = TextProblemStatement(text="Issue for instance-A", id="instance-A")
+    hook.on_instance_start(index=0, env=MagicMock(), problem_statement=ps)
+    result = AgentRunResult(
+        info={"submission": "patch content", "exit_status": "submitted"},
+        trajectory=[],
+    )
+
+    hook.on_instance_completed(result=result)
+
+    trajectory_path = tmp_path / "instance-A" / "instance-A.traj"
+    assert trajectory_path.exists()
+    data = json.loads(trajectory_path.read_text(encoding="utf-8"))
+    assert data["info"]["exit_status"] == "submitted"
+    assert data["info"]["submission"] == "patch content"
+    assert data["trajectory"] == []
+
+
+def test_save_trajectory_hook_concurrent_workers_save_to_correct_dirs(tmp_path):
+    hook = SaveTrajectoryHook()
+    hook._output_dir = tmp_path
+    barrier = threading.Barrier(2)
+
+    def worker(instance_id: str, exit_status: str) -> None:
+        ps = TextProblemStatement(text=f"Issue for {instance_id}", id=instance_id)
+        hook.on_instance_start(index=0, env=MagicMock(), problem_statement=ps)
+        barrier.wait()
+        result = AgentRunResult(
+            info={"submission": None, "exit_status": exit_status},
+            trajectory=[],
+        )
+        hook.on_instance_completed(result=result)
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        fa = pool.submit(worker, "instance-A", "submitted")
+        fb = pool.submit(worker, "instance-B", "early_exit")
+        fa.result()
+        fb.result()
+
+    traj_a = tmp_path / "instance-A" / "instance-A.traj"
+    traj_b = tmp_path / "instance-B" / "instance-B.traj"
+
+    assert traj_a.exists(), "Trajectory for instance-A was not saved to its own directory"
+    assert traj_b.exists(), "Trajectory for instance-B was not saved to its own directory"
+    assert json.loads(traj_a.read_text(encoding="utf-8"))["info"]["exit_status"] == "submitted"
+    assert json.loads(traj_b.read_text(encoding="utf-8"))["info"]["exit_status"] == "early_exit"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
﻿## Summary
- Add a launcher-side `SaveTrajectoryHook` that writes each run result to an instance-specific `.traj` file.
- Register the hook for both single and batch runs so trajectories are saved by default.
- Cover direct saving and concurrent batch-worker isolation.

Fixes #1310.

## Testing
- `UV_LINK_MODE=copy uv run --python 3.11 --extra dev pytest tests/test_run_hooks.py::test_save_trajectory_hook_saves_result_to_instance_dir tests/test_run_hooks.py::test_save_trajectory_hook_concurrent_workers_save_to_correct_dirs`
- `UV_LINK_MODE=copy uv run --python 3.11 --with ruff ruff check sweagent/run/hooks/trajectory.py sweagent/run/run_single.py sweagent/run/run_batch.py tests/test_run_hooks.py`
