### PR TITLE
Preserve sequence arguments in function-call parsers

### DIFF
--- a/sweagent/tools/parsing.py
+++ b/sweagent/tools/parsing.py
@@ -69,6 +69,16 @@ class AbstractParseFunction(ABC):
 # DEFINE NEW PARSING FUNCTIONS BELOW THIS LINE
 
 
+def _format_argument_value(value: Any, command: Command) -> Any:
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return quote(value) if _should_quote(value, command) else value
+    if isinstance(value, list | tuple):
+        return [_format_argument_value(item, command) for item in value]
+    return value
+
+
 class ActionParser(AbstractParseFunction, BaseModel):
     """
     Expects the model response to be a single command.
@@ -309,11 +319,7 @@ class XMLFunctionCallingParser(AbstractParseFunction, BaseModel):
 
         # Format arguments using their individual argument_format
         formatted_args = {
-            arg.name: Template(arg.argument_format).render(
-                value=quote(params_dict[arg.name])
-                if _should_quote(params_dict[arg.name], command)
-                else params_dict[arg.name]
-            )
+            arg.name: Template(arg.argument_format).render(value=_format_argument_value(params_dict[arg.name], command))
             if arg.name in params_dict
             else ""
             for arg in command.arguments
@@ -422,16 +428,8 @@ class FunctionCallingParser(AbstractParseFunction, BaseModel):
             msg = f"Unexpected argument(s): {', '.join(extra_args)}"
             raise FunctionCallingFormatError(msg, "unexpected_arg")
 
-        def get_quoted_arg(value: Any) -> str:
-            if isinstance(value, str):
-                return quote(value) if _should_quote(value, command) else value
-            # See https://github.com/SWE-agent/SWE-agent/issues/1159
-            if value is None:
-                return ""
-            return value
-
         formatted_args = {
-            arg.name: Template(arg.argument_format).render(value=get_quoted_arg(values[arg.name]))
+            arg.name: Template(arg.argument_format).render(value=_format_argument_value(values[arg.name], command))
             if arg.name in values
             else ""
             for arg in command.arguments
@@ -525,8 +523,7 @@ class JsonParser(AbstractParseFunction, BaseModel):
                 for arg in command.arguments:
                     if arg.name in data_command.get("arguments", {}):
                         value = data_command["arguments"][arg.name]
-                        if _should_quote(value, command):
-                            value = quote(value)
+                        value = _format_argument_value(value, command)
                         formatted_args[arg.name] = Template(arg.argument_format).render(value=value)
                     elif strict and arg.required:
                         msg = f"Required argument '{arg.name}' missing for command '{command.name}'"

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -4,7 +4,7 @@ import pytest
 from jinja2 import Template
 
 from sweagent.exceptions import FormatError, FunctionCallingFormatError
-from sweagent.tools.commands import Command
+from sweagent.tools.commands import Argument, Command
 from sweagent.tools.parsing import (
     ActionParser,
     EditFormat,
@@ -12,6 +12,7 @@ from sweagent.tools.parsing import (
     Identity,
     JsonParser,
     ThoughtActionParser,
+    XMLFunctionCallingParser,
     XMLThoughtActionParser,
 )
 
@@ -129,3 +130,127 @@ def test_function_calling_parser_error_message():
     template = Template(FunctionCallingParser().error_message)
     exc1 = FunctionCallingFormatError("test", "missing")
     assert "did not use any tool calls" in template.render(**exc1.extra_info, exception_message=exc1.message)
+
+
+def _str_replace_editor_command() -> Command:
+    return Command(
+        name="str_replace_editor",
+        signature="str_replace_editor <command> <path> [<view_range>] [<old_str>]",
+        docstring="Custom editing tool",
+        arguments=[
+            Argument(
+                name="command",
+                type="string",
+                description="The command to run.",
+                required=True,
+            ),
+            Argument(
+                name="path",
+                type="string",
+                description="Path to file or directory.",
+                required=True,
+            ),
+            Argument(
+                name="view_range",
+                type="array",
+                items={"type": "integer"},
+                description="Line range to view.",
+                required=False,
+                argument_format="--view_range {{value|join(' ')}}",
+            ),
+            Argument(
+                name="old_str",
+                type="string",
+                description="String to replace.",
+                required=False,
+                argument_format="--old_str {{value}}",
+            ),
+        ],
+    )
+
+
+def test_function_calling_parser_preserves_array_arguments():
+    parser = FunctionCallingParser()
+    command = _str_replace_editor_command()
+    model_response = {
+        "message": "View the relevant lines",
+        "tool_calls": [
+            {
+                "function": {
+                    "name": "str_replace_editor",
+                    "arguments": '{"command": "view", "path": "/testbed/file.py", "view_range": [1, 50]}',
+                }
+            }
+        ],
+    }
+
+    thought, action = parser(model_response, [command])
+
+    assert thought == "View the relevant lines"
+    assert action == "str_replace_editor view /testbed/file.py --view_range 1 50"
+
+
+def test_function_calling_parser_preserves_tuple_arguments_from_dict():
+    parser = FunctionCallingParser()
+    command = _str_replace_editor_command()
+    model_response = {
+        "message": "View the relevant lines",
+        "tool_calls": [
+            {
+                "function": {
+                    "name": "str_replace_editor",
+                    "arguments": {"command": "view", "path": "/testbed/file.py", "view_range": (1, 50)},
+                }
+            }
+        ],
+    }
+
+    _, action = parser(model_response, [command])
+
+    assert action == "str_replace_editor view /testbed/file.py --view_range 1 50"
+
+
+def test_function_calling_parser_still_quotes_string_arguments():
+    parser = FunctionCallingParser()
+    command = _str_replace_editor_command()
+    model_response = {
+        "message": "Replace text",
+        "tool_calls": [
+            {
+                "function": {
+                    "name": "str_replace_editor",
+                    "arguments": {
+                        "command": "str_replace",
+                        "path": "/testbed/file.py",
+                        "old_str": "hello world",
+                    },
+                }
+            }
+        ],
+    }
+
+    _, action = parser(model_response, [command])
+
+    assert action == "str_replace_editor str_replace /testbed/file.py  --old_str 'hello world'"
+
+
+def test_xml_function_calling_parser_preserves_array_arguments():
+    parser = XMLFunctionCallingParser()
+    command = _str_replace_editor_command()
+    model_response = {
+        "message": "\n".join(
+            [
+                "View the relevant lines",
+                "<function=str_replace_editor>",
+                "<parameter=command>view</parameter>",
+                "<parameter=path>/testbed/file.py</parameter>",
+                "<parameter=view_range>[1, 50]</parameter>",
+                "</function>",
+            ]
+        )
+    }
+
+    thought, action = parser(model_response, [command])
+
+    assert thought == "View the relevant lines"
+    assert action == "str_replace_editor view /testbed/file.py --view_range 1 50"


### PR DESCRIPTION
﻿## Summary
- Preserve list and tuple tool-call arguments instead of stringifying them.
- Keep existing string quoting behavior for shell-command arguments.
- Add coverage for `str_replace_editor view_range` array/tuple arguments and string quoting.

Fixes #1182.

## Testing
- `UV_LINK_MODE=copy uv run --python 3.11 --extra dev pytest tests/test_parsing.py`
- `UV_LINK_MODE=copy uv run --python 3.11 --extra dev pytest tests/test_agent.py::test_function_calling tests/test_tools_command_parsing.py`
- `UV_LINK_MODE=copy uv run --python 3.11 --with ruff ruff check sweagent/tools/parsing.py tests/test_parsing.py`
