### PR TITLE
Preserve reasoning content in trajectories

### DIFF
--- a/sweagent/agent/agents.py
+++ b/sweagent/agent/agents.py
@@ -1044,6 +1044,7 @@ class DefaultAgent(AbstractAgent):
             # todo: Can't I override the parser in __init__?
             step.thought, step.action = self.tools.parse_actions(output)
             step.thinking_blocks = output.get("thinking_blocks", [])
+            step.reasoning_content = output.get("reasoning_content")
             if output.get("tool_calls") is not None:
                 step.tool_call_ids = [call["id"] for call in output["tool_calls"]]
                 step.tool_calls = output["tool_calls"]
@@ -1230,6 +1231,8 @@ class DefaultAgent(AbstractAgent):
                 "extra_info": step.extra_info,
             },
         )
+        if step.reasoning_content:
+            trajectory_step["reasoning_content"] = step.reasoning_content
         self.trajectory.append(trajectory_step)
 
     def step(self) -> StepOutput:

--- a/sweagent/agent/models.py
+++ b/sweagent/agent/models.py
@@ -545,6 +545,10 @@ class PredeterminedTestModel(AbstractModel):
         result = {"message": output["message"]}
         if "tool_calls" in output:
             result["tool_calls"] = output["tool_calls"]
+        if "reasoning_content" in output:
+            result["reasoning_content"] = output["reasoning_content"]
+        if "thinking_blocks" in output:
+            result["thinking_blocks"] = output["thinking_blocks"]
         return result
 
 
@@ -687,6 +691,8 @@ class LiteLLMModel(AbstractModel):
                 del message["cache_control"]
             if "thinking_blocks" in message:
                 del message["thinking_blocks"]
+            if "reasoning_content" in message:
+                del message["reasoning_content"]
         input_tokens: int = litellm.utils.token_counter(
             messages=messages_no_cache_control,
             model=self.custom_tokenizer["identifier"] if self.custom_tokenizer is not None else self.config.name,
@@ -771,11 +777,16 @@ class LiteLLMModel(AbstractModel):
                 else:
                     tool_calls = []
                 output_dict["tool_calls"] = tool_calls
-            if (
-                hasattr(response.choices[i].message, "thinking_blocks")  # type: ignore
-                and response.choices[i].message.thinking_blocks  # type: ignore
-            ):
-                output_dict["thinking_blocks"] = response.choices[i].message.thinking_blocks  # type: ignore
+            message = response.choices[i].message
+            if hasattr(message, "thinking_blocks") and message.thinking_blocks:  # type: ignore
+                output_dict["thinking_blocks"] = message.thinking_blocks  # type: ignore
+            reasoning_content = getattr(message, "reasoning_content", None)
+            if not isinstance(reasoning_content, str):
+                provider_fields = getattr(message, "provider_specific_fields", None) or {}
+                if isinstance(provider_fields, dict):
+                    reasoning_content = provider_fields.get("reasoning_content")
+            if isinstance(reasoning_content, str) and reasoning_content:
+                output_dict["reasoning_content"] = reasoning_content
             outputs.append(output_dict)
         self._update_stats(input_tokens=input_tokens, output_tokens=output_tokens, cost=cost)
         return outputs

--- a/sweagent/types.py
+++ b/sweagent/types.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from typing import Any, Literal
 
 from pydantic import BaseModel
-from typing_extensions import TypedDict
+from typing_extensions import NotRequired, TypedDict
 
 
 class StepOutput(BaseModel):
@@ -26,6 +26,7 @@ class StepOutput(BaseModel):
     tool_calls: list[dict[str, Any]] | None = None
     tool_call_ids: list[str] | None = None
     thinking_blocks: list[dict[str, Any]] | None = None
+    reasoning_content: str | None = None
 
     """State of the environment at the end of the step"""
     extra_info: dict[str, Any] = {}
@@ -34,7 +35,7 @@ class StepOutput(BaseModel):
         """Used for formatting (error) prompt templates"""
         out = {}
         for k, v in self.model_dump().items():
-            if k in ("tool_calls", "tool_call_ids", "state"):
+            if k in ("tool_calls", "tool_call_ids", "state", "reasoning_content"):
                 continue
             out[k] = v
         out |= self.state
@@ -50,6 +51,7 @@ class TrajectoryStep(TypedDict):
     execution_time: float
     query: list[dict[str, Any]]
     extra_info: dict[str, Any]
+    reasoning_content: NotRequired[str]
 
 
 # required fields go here
@@ -70,6 +72,7 @@ class HistoryItem(_HistoryItem, total=False):
     tags: list[str]
     cache_control: dict[str, Any] | None
     thinking_blocks: list[dict[str, Any]] | None
+    reasoning_content: str | None
 
     """HistoryProcessors can add these tags to enable special processing"""
 

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -11,6 +11,7 @@ from sweagent.agent.problem_statement import EmptyProblemStatement, TextProblemS
 from sweagent.environment.swe_env import SWEEnv
 from sweagent.tools.parsing import FunctionCallingParser, Identity, ThoughtActionParser
 from sweagent.tools.tools import ToolConfig
+from sweagent.types import StepOutput
 
 
 def test_dummy_env(dummy_env):
@@ -260,3 +261,15 @@ def test_function_calling(dummy_env: SWEEnv, function_calling_agent: DefaultAgen
     assert not r.done, "Expected not done, because we haven't submitted yet"
     assert r.action.strip() == "ls", "Expected the tool call to be executed"
     assert "file1 file2" in r.observation, "Expected the tool call to return the output of the command"
+
+
+def test_add_step_to_trajectory_preserves_reasoning_content(default_agent: DefaultAgent):
+    step = StepOutput(
+        action="ls",
+        output="```ls```",
+        reasoning_content="model reasoning",
+    )
+
+    default_agent.add_step_to_trajectory(step)
+
+    assert default_agent.trajectory[-1]["reasoning_content"] == "model reasoning"

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -31,6 +31,8 @@ def _make_mock_response(content: str = "mock") -> MagicMock:
     choice = MagicMock()
     choice.message.content = content
     choice.message.tool_calls = None
+    choice.message.thinking_blocks = None
+    choice.message.reasoning_content = None
     response = MagicMock()
     response.choices = [choice]
     response.usage.prompt_tokens = 10
@@ -104,3 +106,23 @@ def test_user_agent_header_with_other_extra_headers():
         extra_headers = call_kwargs.kwargs.get("extra_headers", {})
         assert extra_headers["User-Agent"] == f"swe-agent/{__version__}"
         assert extra_headers["X-Custom"] == "value"
+
+
+def test_reasoning_content_is_preserved_in_model_output():
+    model = get_model(
+        GenericAPIModelConfig(
+            name="gpt-4o",
+            api_key=SecretStr("dummy_key"),
+            top_p=None,
+            per_instance_cost_limit=0,
+            total_cost_limit=0,
+        ),
+        ToolConfig(parse_function=Identity()),
+    )
+    mock_response = _make_mock_response("final answer")
+    mock_response.choices[0].message.reasoning_content = "model reasoning"
+
+    with patch("litellm.completion", return_value=mock_response):
+        output = model.query(History([{"role": "user", "content": "test"}]))
+
+    assert output == {"message": "final answer", "reasoning_content": "model reasoning"}


### PR DESCRIPTION
﻿## Summary
- Carry provider `reasoning_content` through model output, step output, history items, and trajectory serialization.
- Strip `reasoning_content` before token counting, matching existing `thinking_blocks` handling.
- Add model and agent tests proving reasoning content is preserved.

Fixes #1333.

## Testing
- `UV_LINK_MODE=copy uv run --python 3.11 --extra dev pytest tests/test_models.py tests/test_agent.py::test_add_step_to_trajectory_preserves_reasoning_content`
- `UV_LINK_MODE=copy uv run --python 3.11 --with ruff ruff check sweagent/agent/models.py sweagent/agent/agents.py sweagent/types.py tests/test_models.py tests/test_agent.py`
