### PR TITLE
Use python -m pip in tool install scripts

### DIFF
--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -1,7 +1,24 @@
 from __future__ import annotations
 
+from pathlib import Path
+
 from sweagent import __version__
 
 
 def test_version():
     assert __version__.count(".") == 2
+
+
+def test_tool_install_scripts_do_not_require_pip_executable():
+    repo_root = Path(__file__).resolve().parents[1]
+    install_scripts = sorted((repo_root / "tools").glob("*/install.sh"))
+    assert install_scripts
+
+    offenders = []
+    for script in install_scripts:
+        for line_number, line in enumerate(script.read_text(encoding="utf-8").splitlines(), start=1):
+            stripped = line.strip()
+            if stripped.startswith("pip install"):
+                offenders.append(f"{script.relative_to(repo_root)}:{line_number}")
+
+    assert offenders == []

--- a/tools/edit_anthropic/install.sh
+++ b/tools/edit_anthropic/install.sh
@@ -1,3 +1,3 @@
 # Ignore failures, see https://github.com/SWE-agent/SWE-agent/issues/1179
-pip install 'tree-sitter==0.21.3' || true
-pip install 'tree-sitter-languages' || true
+python -m pip install 'tree-sitter==0.21.3' || true
+python -m pip install 'tree-sitter-languages' || true

--- a/tools/filemap/install.sh
+++ b/tools/filemap/install.sh
@@ -1,2 +1,2 @@
-pip install 'tree-sitter==0.21.3'
-pip install 'tree-sitter-languages'
+python -m pip install 'tree-sitter==0.21.3'
+python -m pip install 'tree-sitter-languages'

--- a/tools/windowed_edit_linting/install.sh
+++ b/tools/windowed_edit_linting/install.sh
@@ -2,4 +2,4 @@ _write_env "CURRENT_FILE" "${CURRENT_FILE:-}"
 _write_env "CURRENT_LINE" "${CURRENT_LINE:-0}"
 _write_env "WINDOW" "$WINDOW"
 
-pip install flake8
+python -m pip install flake8

--- a/tools/windowed_edit_replace/install.sh
+++ b/tools/windowed_edit_replace/install.sh
@@ -2,4 +2,4 @@ _write_env "CURRENT_FILE" "${CURRENT_FILE:-}"
 _write_env "CURRENT_LINE" "${CURRENT_LINE:-0}"
 _write_env "WINDOW" "$WINDOW"
 
-pip install flake8
+python -m pip install flake8

--- a/tools/windowed_edit_rewrite/install.sh
+++ b/tools/windowed_edit_rewrite/install.sh
@@ -2,4 +2,4 @@ _write_env "CURRENT_FILE" "${CURRENT_FILE:-}"
 _write_env "CURRENT_LINE" "${CURRENT_LINE:-0}"
 _write_env "WINDOW" "$WINDOW"
 
-pip install flake8
+python -m pip install flake8


### PR DESCRIPTION
﻿## Summary
- Replace bare `pip install` calls in tool install scripts with `python -m pip install`.
- Add a packaging regression test so future install scripts do not require a `pip` executable on PATH.

Fixes #1170.

## Testing
- `UV_LINK_MODE=copy uv run --python 3.11 --extra dev pytest tests/test_packaging.py`
- `rg -n "^\s*pip install" tools -g 'install.sh'`
- `UV_LINK_MODE=copy uv run --python 3.11 --with ruff ruff check tests/test_packaging.py`
