### PR TITLE
Preserve CRLF line endings in generated patches

### DIFF
--- a/sweagent/agent/agents.py
+++ b/sweagent/agent/agents.py
@@ -884,7 +884,12 @@ class DefaultAgent(AbstractAgent):
         if is_submission or force_submission:
             assert self._env is not None
             try:
-                submission = self._env.read_file("/root/model.patch", encoding="utf-8", errors="backslashreplace")
+                submission = self._env.read_file(
+                    "/root/model.patch",
+                    encoding="utf-8",
+                    errors="backslashreplace",
+                    preserve_newlines=True,
+                )
             except FileNotFoundError:
                 self.logger.warning("Submission file not found, no submission was made")
                 return step

--- a/sweagent/environment/swe_env.py
+++ b/sweagent/environment/swe_env.py
@@ -1,4 +1,6 @@
 import asyncio
+import base64
+import locale
 import logging
 import shlex
 from pathlib import PurePath
@@ -231,7 +233,14 @@ class SWEEnv:
                 raise RuntimeError(msg)
         return output
 
-    def read_file(self, path: str | PurePath, encoding: str | None = None, errors: str | None = None) -> str:
+    def read_file(
+        self,
+        path: str | PurePath,
+        encoding: str | None = None,
+        errors: str | None = None,
+        *,
+        preserve_newlines: bool = False,
+    ) -> str:
         """Read file contents from container
 
         Args:
@@ -240,10 +249,29 @@ class SWEEnv:
                 This is the same as the `encoding` argument of `Path.read_text()`
             errors: Error handling to use when reading the file. None means default error handling.
                 This is the same as the `errors` argument of `Path.read_text()`
+            preserve_newlines: If True, read bytes and decode them without Python's universal newline
+                conversion. This is useful for patch files where CRLF vs LF must be preserved.
 
         Returns:
             file_contents: Contents of file as string
         """
+        if preserve_newlines:
+            read_bytes = (
+                "import base64, pathlib, sys; "
+                "sys.stdout.write(base64.b64encode(pathlib.Path(sys.argv[1]).read_bytes()).decode('ascii'))"
+            )
+            r = asyncio.run(
+                self.deployment.runtime.execute(
+                    RexCommand(
+                        command=["python", "-c", read_bytes, str(path)],
+                        check=True,
+                        error_msg=f"Failed to read file {path!s}",
+                    )
+                )
+            )
+            file_bytes = base64.b64decode(r.stdout.encode("ascii"))
+            return file_bytes.decode(encoding or locale.getpreferredencoding(False), errors=errors or "strict")
+
         r = asyncio.run(
             self.deployment.runtime.read_file(ReadFileRequest(path=str(path), encoding=encoding, errors=errors))
         )

--- a/sweagent/run/hooks/apply_patch.py
+++ b/sweagent/run/hooks/apply_patch.py
@@ -86,7 +86,7 @@ class SaveApplyPatchHook(RunHook):
             self.logger.info("No patch to save.")
             return None
         model_patch = info["submission"]
-        patch_output_file.write_text(model_patch)
+        patch_output_file.write_text(model_patch, encoding="utf-8", errors="backslashreplace", newline="")
         if _is_promising_patch(info):
             # Only print big congratulations if we actually believe
             # the patch will solve the issue

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -11,6 +11,7 @@ from sweagent.agent.problem_statement import EmptyProblemStatement, TextProblemS
 from sweagent.environment.swe_env import SWEEnv
 from sweagent.tools.parsing import FunctionCallingParser, Identity, ThoughtActionParser
 from sweagent.tools.tools import ToolConfig
+from sweagent.types import StepOutput
 
 
 def test_dummy_env(dummy_env):
@@ -217,6 +218,36 @@ def test_show_no_output_template(dummy_env: SWEEnv, default_agent: DefaultAgent,
     a.step()
     a.step()
     # todo: actually test that the template is used
+
+
+def test_handle_submission_preserves_patch_newlines(
+    monkeypatch: pytest.MonkeyPatch, dummy_env: SWEEnv, default_agent: DefaultAgent
+):
+    a = default_agent
+    a.setup(dummy_env, EmptyProblemStatement())
+    read_kwargs = {}
+
+    def read_file(path, encoding=None, errors=None, *, preserve_newlines=False):
+        read_kwargs.update(
+            path=path,
+            encoding=encoding,
+            errors=errors,
+            preserve_newlines=preserve_newlines,
+        )
+        return "diff --git a/file.txt b/file.txt\r\n+changed\r\n"
+
+    monkeypatch.setattr(dummy_env, "read_file", read_file)
+
+    step = a.handle_submission(StepOutput(observation="<<SWE_AGENT_SUBMISSION>>"))
+
+    assert read_kwargs == {
+        "path": "/root/model.patch",
+        "encoding": "utf-8",
+        "errors": "backslashreplace",
+        "preserve_newlines": True,
+    }
+    assert step.submission == "diff --git a/file.txt b/file.txt\r\n+changed\r\n"
+    assert step.observation == step.submission
 
 
 # todo: fixme; Needs real environment or mocking of read_file

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
+import base64
 from pathlib import Path
 from unittest import mock
 
 import pytest
 from swerex.exceptions import CommandTimeoutError
+from swerex.runtime.abstract import Command, CommandResponse
+from swerex.runtime.dummy import DummyRuntime
 
 from sweagent.environment.hooks.abstract import EnvHook
 
@@ -38,6 +41,35 @@ def test_read_file(tmp_path, test_env_args):
     with swe_env_context(test_env_args) as env:
         content = env.read_file(Path("tests/filetoread.txt"))
         assert content.splitlines()[-1].strip() == "SWEEnv.read_file"
+
+
+def test_read_file_preserve_newlines(dummy_env):
+    class BytesRuntime(DummyRuntime):
+        def __init__(self):
+            super().__init__()
+            self.command: Command | None = None
+
+        async def execute(self, command: Command) -> CommandResponse:
+            self.command = command
+            content = base64.b64encode(b"line1\r\nline2\rline3\n").decode("ascii")
+            return CommandResponse(stdout=content, exit_code=0)
+
+    runtime = BytesRuntime()
+    dummy_env.deployment.runtime = runtime  # type: ignore[assignment]
+
+    content = dummy_env.read_file("/root/model.patch", encoding="utf-8", preserve_newlines=True)
+
+    assert content == "line1\r\nline2\rline3\n"
+    assert runtime.command is not None
+    assert runtime.command.command == [
+        "python",
+        "-c",
+        (
+            "import base64, pathlib, sys; "
+            "sys.stdout.write(base64.b64encode(pathlib.Path(sys.argv[1]).read_bytes()).decode('ascii'))"
+        ),
+        "/root/model.patch",
+    ]
 
 
 @pytest.mark.slow

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -1,7 +1,19 @@
 from __future__ import annotations
 
+from pathlib import Path
+
 from sweagent import __version__
+
+ROOT = Path(__file__).resolve().parent.parent
 
 
 def test_version():
     assert __version__.count(".") == 2
+
+
+def test_tool_patch_readers_preserve_newlines():
+    for script in [
+        ROOT / "tools" / "review_on_submit_m" / "bin" / "submit",
+        ROOT / "tools" / "diff_state" / "bin" / "_state_diff_state",
+    ]:
+        assert 'newline=""' in script.read_text()

--- a/tests/test_run_hooks.py
+++ b/tests/test_run_hooks.py
@@ -130,6 +130,17 @@ def test_save_apply_patch_hook_concurrent_workers_save_to_correct_dirs(tmp_path)
     assert patch_b.read_text() == "patch B content"
 
 
+def test_save_apply_patch_hook_preserves_patch_newlines(tmp_path):
+    hook = SaveApplyPatchHook(show_success_message=False)
+    hook._output_dir = tmp_path
+    patch_content = "diff --git a/file.txt b/file.txt\r\n+changed\r\n"
+
+    patch_path = hook._save_patch("instance-crlf", {"submission": patch_content})
+
+    assert patch_path == tmp_path / "instance-crlf" / "instance-crlf.patch"
+    assert patch_path.read_bytes() == patch_content.encode("utf-8")
+
+
 @pytest.mark.parametrize(
     ("subset", "expected"),
     [

--- a/tools/diff_state/bin/_state_diff_state
+++ b/tools/diff_state/bin/_state_diff_state
@@ -3,8 +3,8 @@
 def main() -> None:
     import json
     import os
-    from pathlib import Path
     import subprocess
+    from pathlib import Path
 
     from registry import registry
 
@@ -26,15 +26,16 @@ def main() -> None:
         cwd=repo_root,
     )
 
-    patch = patch_path.read_text(errors="backslashreplace")
+    with patch_path.open(errors="backslashreplace", newline="") as f:
+        patch = f.read()
     state["diff"] = patch.strip()
 
     state_path.write_text(json.dumps(state))
 
 
 def _del_diff():
-    from pathlib import Path
     import json
+    from pathlib import Path
 
     state_path = Path("/root/state.json")
     if state_path.exists():
@@ -48,5 +49,5 @@ def _del_diff():
 if __name__ == "__main__":
     try:
         main()
-    except Exception as e:
+    except Exception:
         _del_diff()

--- a/tools/review_on_submit_m/bin/submit
+++ b/tools/review_on_submit_m/bin/submit
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
 
 import argparse
-from pathlib import Path
+import io
+import os
 import subprocess
 import sys
-import os
-import io
+from pathlib import Path
 
 from registry import registry
 
@@ -28,7 +28,8 @@ def main() -> None:
         cwd=repo_root,
     )
 
-    patch = patch_path.read_text(errors="backslashreplace")
+    with patch_path.open(errors="backslashreplace", newline="") as f:
+        patch = f.read()
 
     submit_review_messages = registry.get("SUBMIT_REVIEW_MESSAGES", [])
     n_stages = len(submit_review_messages)


### PR DESCRIPTION
﻿## Summary
- Add an opt-in newline-preserving read path for patch files so CRLF bytes are not normalized by Python text reads.
- Use the preserving path when collecting `/root/model.patch` submissions.
- Preserve patch line endings when saving patch files locally and when reading patches inside submit/diff-state helper scripts.
- Add regression tests for patch read, submission handling, patch saving, and helper-script coverage.

Fixes #702.

## Testing
- `UV_LINK_MODE=copy uv run --python 3.11 --extra dev pytest tests/test_env.py::test_read_file_preserve_newlines tests/test_agent.py::test_handle_submission_preserves_patch_newlines tests/test_run_hooks.py::test_save_apply_patch_hook_preserves_patch_newlines tests/test_packaging.py`
- `UV_LINK_MODE=copy uv run --python 3.11 --with ruff ruff check sweagent/environment/swe_env.py sweagent/agent/agents.py sweagent/run/hooks/apply_patch.py tools/review_on_submit_m/bin/submit tools/diff_state/bin/_state_diff_state tests/test_env.py tests/test_agent.py tests/test_run_hooks.py tests/test_packaging.py`
