### PR TITLE
fix(inspector): prevent path traversal in web trajectory server (#1472)

### DIFF
--- a/docs/usage/inspector.md
+++ b/docs/usage/inspector.md
@@ -59,6 +59,13 @@ The inspector will then be launched in the browser:
 
 - `--directory`: Directory of trajectories to inspect (Defaults to current directory)
 - `--port`: Port to host web app (Defaults to `8000`).
+- `--host`: Interface to bind to (Defaults to `127.0.0.1`, i.e. only reachable from your own machine).
+
+!!! warning
+    The web inspector has no authentication and serves your trajectory files, which
+    can contain secrets such as API keys. It binds to loopback (`127.0.0.1`) by default.
+    Only pass `--host 0.0.0.0` if you understand that this exposes the trajectories to
+    anyone who can reach the port, and make sure the machine is otherwise protected.
 
 ## Benchmark results
 

--- a/sweagent/inspector/server.py
+++ b/sweagent/inspector/server.py
@@ -4,12 +4,34 @@ import http.server
 import json
 import os
 import socketserver
+import urllib.parse
 from argparse import ArgumentParser
 from functools import partial
 from pathlib import Path
 from typing import Any
 
 import yaml
+
+
+def resolve_traj_path(traj_dir: str | os.PathLike, file_path: str) -> Path | None:
+    """Safely resolve a requested trajectory file within ``traj_dir``.
+
+    The inspector serves files from ``traj_dir`` based on the (attacker-controlled)
+    request path. To prevent path-traversal escapes, the request path is
+    percent-decoded, resolved against ``traj_dir`` and checked to make sure it
+    stays inside ``traj_dir``.
+
+    Returns the resolved absolute path, or ``None`` if the path escapes the
+    directory (e.g. ``..`` traversal, absolute paths, or symlink escapes).
+    """
+    # Drop any query string / fragment and percent-decode before resolving so
+    # that encoded traversal sequences (e.g. ``%2e%2e``) cannot slip through.
+    decoded = urllib.parse.unquote(file_path.split("?", 1)[0].split("#", 1)[0])
+    base = Path(traj_dir).resolve()
+    candidate = (base / decoded).resolve()
+    if candidate != base and base not in candidate.parents:
+        return None
+    return candidate
 
 
 def add_problem_statement(content):
@@ -238,9 +260,13 @@ class Handler(http.server.SimpleHTTPRequestHandler):
         self.wfile.write(json.dumps({"directory": self.traj_dir}).encode())
 
     def serve_file_content(self, file_path):
+        safe_path = resolve_traj_path(self.traj_dir, file_path)
+        if safe_path is None:
+            self.send_error(403, "Forbidden")
+            return
         try:
             content = load_content(
-                Path(self.traj_dir) / file_path,
+                safe_path,
                 self.gold_patches,
                 self.test_patches,
             )
@@ -287,12 +313,8 @@ class Handler(http.server.SimpleHTTPRequestHandler):
             self.send_response(204)  # Send no content response if no update
         self.end_headers()
 
-    def end_headers(self):
-        self.send_header("Access-Control-Allow-Origin", "*")
-        super().end_headers()
 
-
-def main(data_path, directory, port):
+def main(data_path, directory, port, host="127.0.0.1"):
     data = []
     if data_path is not None:
         if data_path.endswith(".jsonl"):
@@ -319,8 +341,14 @@ def main(data_path, directory, port):
         test_patches=test_patches,
     )
     try:
-        with socketserver.TCPServer(("", port), handler_with_directory) as httpd:
-            print(f"Serving at http://localhost:{port}")
+        with socketserver.TCPServer((host, port), handler_with_directory) as httpd:
+            display_host = "localhost" if host in ("", "0.0.0.0", "127.0.0.1") else host
+            print(f"Serving at http://{display_host}:{port}")
+            if host in ("", "0.0.0.0"):
+                print(
+                    "WARNING: The inspector is bound to all interfaces and has no authentication. "
+                    "Anyone who can reach this port can read the served trajectories."
+                )
             httpd.serve_forever()
     except OSError as e:
         if e.errno == 48:
@@ -338,6 +366,12 @@ def get_parser():
     )
     parser.add_argument("--directory", type=str, help="Directory to serve", default=os.getcwd(), nargs="?")
     parser.add_argument("--port", type=int, help="Port to serve", default=8000)
+    parser.add_argument(
+        "--host",
+        type=str,
+        help="Host/interface to bind to. Defaults to loopback; pass 0.0.0.0 to expose on all interfaces.",
+        default="127.0.0.1",
+    )
     return parser
 
 

--- a/tests/test_inspector.py
+++ b/tests/test_inspector.py
@@ -1,0 +1,156 @@
+"""Tests for the trajectory inspector HTTP server, focusing on the
+path-traversal protection of the ``/trajectory/`` endpoint (issue #1472)."""
+
+from __future__ import annotations
+
+import json
+import socket
+import socketserver
+import threading
+from functools import partial
+from http.client import HTTPConnection
+from pathlib import Path
+
+import pytest
+
+from sweagent.inspector.server import Handler, resolve_traj_path
+
+
+def _write_traj(path: Path, marker: str) -> None:
+    """Write a minimal trajectory-shaped JSON file to *path*."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {
+                "history": [{"role": "user", "content": marker}],
+                "trajectory": [],
+                "info": {},
+            }
+        )
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Unit tests for resolve_traj_path
+# --------------------------------------------------------------------------- #
+
+
+def test_resolve_traj_path_allows_file_inside_dir(tmp_path: Path) -> None:
+    (tmp_path / "run.traj").write_text("{}")
+    resolved = resolve_traj_path(tmp_path, "run.traj")
+    assert resolved == (tmp_path / "run.traj").resolve()
+
+
+def test_resolve_traj_path_allows_nested_file(tmp_path: Path) -> None:
+    nested = tmp_path / "sub" / "run.traj"
+    nested.parent.mkdir()
+    nested.write_text("{}")
+    resolved = resolve_traj_path(tmp_path, "sub/run.traj")
+    assert resolved == nested.resolve()
+
+
+@pytest.mark.parametrize(
+    "escape",
+    [
+        "../secret.json",
+        "../../secret.json",
+        "..%2Fsecret.json",  # percent-encoded slash
+        "%2e%2e/secret.json",  # percent-encoded dots
+        "sub/../../secret.json",
+        "/etc/passwd",  # absolute path escape
+    ],
+)
+def test_resolve_traj_path_rejects_escapes(tmp_path: Path, escape: str) -> None:
+    served = tmp_path / "served"
+    served.mkdir()
+    # A sensitive file living *outside* the served directory.
+    (tmp_path / "secret.json").write_text("{}")
+    assert resolve_traj_path(served, escape) is None
+
+
+def test_resolve_traj_path_strips_query_string(tmp_path: Path) -> None:
+    (tmp_path / "run.traj").write_text("{}")
+    resolved = resolve_traj_path(tmp_path, "run.traj?foo=bar")
+    assert resolved == (tmp_path / "run.traj").resolve()
+
+
+# --------------------------------------------------------------------------- #
+# Integration test: boot the real server and send raw requests
+# --------------------------------------------------------------------------- #
+
+
+def _raw_get(host: str, port: int, raw_path: str) -> tuple[int, dict[str, str], bytes]:
+    """Send a GET whose request-line path is *raw_path* verbatim.
+
+    Using a raw socket (instead of a normalizing HTTP client) ensures literal
+    ``..`` segments reach the server, mirroring ``curl --path-as-is``.
+    """
+    with socket.create_connection((host, port), timeout=5) as sock:
+        request = f"GET {raw_path} HTTP/1.1\r\nHost: {host}:{port}\r\nConnection: close\r\n\r\n"
+        sock.sendall(request.encode())
+        chunks = []
+        while True:
+            data = sock.recv(4096)
+            if not data:
+                break
+            chunks.append(data)
+    raw = b"".join(chunks)
+    header_blob, _, body = raw.partition(b"\r\n\r\n")
+    lines = header_blob.decode("latin-1").split("\r\n")
+    status = int(lines[0].split(" ")[1])
+    headers = {}
+    for line in lines[1:]:
+        if ":" in line:
+            key, _, value = line.partition(":")
+            headers[key.strip().lower()] = value.strip()
+    return status, headers, body
+
+
+@pytest.fixture
+def running_inspector(tmp_path: Path):
+    served = tmp_path / "served"
+    served.mkdir()
+    _write_traj(served / "good.traj", "public-content")
+    # Trajectory-shaped secret sitting outside the served directory.
+    _write_traj(tmp_path / "secret.json", "TOP-SECRET-API-KEY")
+
+    handler = partial(Handler, directory=str(served), gold_patches={}, test_patches={})
+
+    class _Server(socketserver.ThreadingTCPServer):
+        allow_reuse_address = True
+
+    httpd = _Server(("127.0.0.1", 0), handler)
+    host, port = httpd.server_address
+    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield host, port
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        thread.join(timeout=5)
+
+
+def test_server_serves_valid_trajectory(running_inspector) -> None:
+    host, port = running_inspector
+    conn = HTTPConnection(host, port, timeout=5)
+    conn.request("GET", "/trajectory/good.traj")
+    response = conn.getresponse()
+    assert response.status == 200
+    body = response.read()
+    conn.close()
+    assert b"public-content" in body
+
+
+def test_server_blocks_path_traversal(running_inspector) -> None:
+    host, port = running_inspector
+    status, _headers, body = _raw_get(host, port, "/trajectory/../secret.json")
+    assert status == 403
+    assert b"TOP-SECRET-API-KEY" not in body
+
+
+def test_server_does_not_send_wildcard_cors(running_inspector) -> None:
+    host, port = running_inspector
+    status, headers, _body = _raw_get(host, port, "/trajectory/good.traj")
+    assert status == 200
+    assert headers.get("access-control-allow-origin") != "*"


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #1472

#### What does this implement/fix? Explain your changes.

The web trajectory inspector (`sweagent inspector`, `sweagent/inspector/server.py`) was vulnerable to path traversal. `do_GET` handled `/trajectory/<path>` *before* delegating to `SimpleHTTPRequestHandler`, so its built-in `..` sanitization was bypassed, and `serve_file_content` joined the request path to the served directory with no check (`Path(self.traj_dir) / file_path`). Because the server also bound to all interfaces (`("", port)`) and sent `Access-Control-Allow-Origin: *`, an unauthenticated client could read trajectory-shaped JSON files from outside the served directory. Trajectories frequently contain repository contents, command output and secrets/API keys, so this is a real disclosure risk.

**Changes (`sweagent/inspector/server.py`):**

- **Path traversal fix (core).** New `resolve_traj_path()` percent-decodes the request path (also strips any query/fragment), resolves it against the served directory, and returns `None` if the result escapes that directory — covering `..` traversal, absolute paths (e.g. `/etc/passwd`), encoded traversal (`%2e%2e`), and symlink escapes. `serve_file_content` now returns **403** for such requests instead of reading the file.
- **Bind to loopback by default.** The server now binds `127.0.0.1` instead of all interfaces. A new `--host` flag lets users opt back into `0.0.0.0`, and a warning is printed when they do. This matches how comparable local dev tools (Jupyter, TensorBoard) default.
- **Drop wildcard CORS.** The built-in UI fetches same-origin (`getBaseUrl()` derives everything from `window.location`), so the `Access-Control-Allow-Origin: *` header was unnecessary for it; removing it closes the cross-origin / DNS-rebinding read vector.

**Tests (`tests/test_inspector.py`, new):**

- Unit tests for `resolve_traj_path` — files inside the dir (incl. nested) resolve; `..`, absolute, and percent-encoded escapes return `None`.
- Integration tests that boot the real server: a valid trajectory returns 200, a raw request with literal `..` (mirroring `curl --path-as-is`) returns 403 and does not leak the off-path secret, and no wildcard CORS header is sent.

**Docs (`docs/usage/inspector.md`):** document the new `--host` flag / loopback default and add a security note.

Note: the default bind change is a minor behavior change — anyone who currently relies on reaching the inspector from another machine now needs to pass `--host 0.0.0.0` explicitly.
