### PR TITLE
fix(parsing): coerce array arguments returned as JSON strings (#1182)

### DIFF
--- a/sweagent/tools/parsing.py
+++ b/sweagent/tools/parsing.py
@@ -45,8 +45,29 @@ from jinja2 import Template
 from pydantic import BaseModel
 
 from sweagent.exceptions import FormatError, FunctionCallingFormatError
-from sweagent.tools.commands import Command
+from sweagent.tools.commands import Argument, Command
 from sweagent.tools.utils import _should_quote
+
+
+def _coerce_array_argument(value: Any, argument: Argument) -> Any:
+    """Coerce array-typed arguments that the model returned as a string.
+
+    Some models/providers return an ``array`` argument as a JSON-encoded string
+    (e.g. ``"[1, 50]"``) instead of an actual list. When such a string is later
+    rendered with a Jinja ``join`` filter it is iterated character by character,
+    producing broken output like ``[ 1 ,   5 0 ]`` (see issue #1182). If the
+    declared type is ``array`` and the value is a JSON string encoding a list,
+    parse it back into a list so the declared type is respected. Anything that
+    does not parse into a list is returned unchanged.
+    """
+    if argument.type == "array" and isinstance(value, str):
+        try:
+            parsed = json.loads(value)
+        except json.JSONDecodeError:
+            return value
+        if isinstance(parsed, list):
+            return parsed
+    return value
 
 
 class AbstractParseFunction(ABC):
@@ -308,15 +329,14 @@ class XMLFunctionCallingParser(AbstractParseFunction, BaseModel):
             raise FormatError(msg)
 
         # Format arguments using their individual argument_format
+        def _render_xml_arg(arg: Argument) -> str:
+            value = _coerce_array_argument(params_dict[arg.name], arg)
+            if _should_quote(value, command):
+                value = quote(value)
+            return Template(arg.argument_format).render(value=value)
+
         formatted_args = {
-            arg.name: Template(arg.argument_format).render(
-                value=quote(params_dict[arg.name])
-                if _should_quote(params_dict[arg.name], command)
-                else params_dict[arg.name]
-            )
-            if arg.name in params_dict
-            else ""
-            for arg in command.arguments
+            arg.name: _render_xml_arg(arg) if arg.name in params_dict else "" for arg in command.arguments
         }
         return thought, command.invoke_format.format(**formatted_args).strip()
 
@@ -431,7 +451,9 @@ class FunctionCallingParser(AbstractParseFunction, BaseModel):
             return value
 
         formatted_args = {
-            arg.name: Template(arg.argument_format).render(value=get_quoted_arg(values[arg.name]))
+            arg.name: Template(arg.argument_format).render(
+                value=get_quoted_arg(_coerce_array_argument(values[arg.name], arg))
+            )
             if arg.name in values
             else ""
             for arg in command.arguments
@@ -524,7 +546,7 @@ class JsonParser(AbstractParseFunction, BaseModel):
             if command.arguments:
                 for arg in command.arguments:
                     if arg.name in data_command.get("arguments", {}):
-                        value = data_command["arguments"][arg.name]
+                        value = _coerce_array_argument(data_command["arguments"][arg.name], arg)
                         if _should_quote(value, command):
                             value = quote(value)
                         formatted_args[arg.name] = Template(arg.argument_format).render(value=value)

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -162,7 +162,7 @@ def test_coerce_array_argument():
     assert _coerce_array_argument([1, 50], array_arg) == [1, 50]
     # Non-array-typed args are never coerced
     assert _coerce_array_argument("[1, 50]", string_arg) == "[1, 50]"
-    # Unparseable / non-list values are returned unchanged
+    # Unparsable / non-list values are returned unchanged
     assert _coerce_array_argument("not json", array_arg) == "not json"
     assert _coerce_array_argument("5", array_arg) == "5"
 

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -4,7 +4,7 @@ import pytest
 from jinja2 import Template
 
 from sweagent.exceptions import FormatError, FunctionCallingFormatError
-from sweagent.tools.commands import Command
+from sweagent.tools.commands import Argument, Command
 from sweagent.tools.parsing import (
     ActionParser,
     EditFormat,
@@ -13,6 +13,7 @@ from sweagent.tools.parsing import (
     JsonParser,
     ThoughtActionParser,
     XMLThoughtActionParser,
+    _coerce_array_argument,
 )
 
 
@@ -129,3 +130,75 @@ def test_function_calling_parser_error_message():
     template = Template(FunctionCallingParser().error_message)
     exc1 = FunctionCallingFormatError("test", "missing")
     assert "did not use any tool calls" in template.render(**exc1.extra_info, exception_message=exc1.message)
+
+
+def _view_range_command() -> Command:
+    """A str_replace_editor-like command with an array-typed ``view_range`` arg."""
+    return Command(
+        name="str_replace_editor",
+        docstring="",
+        signature="str_replace_editor <command> <path> [<view_range>]",
+        arguments=[
+            Argument(name="command", type="string", description="", required=True),
+            Argument(name="path", type="string", description="", required=True),
+            Argument(
+                name="view_range",
+                type="array",
+                items={"type": "integer"},
+                description="",
+                required=False,
+                argument_format="--view_range {{value|join(' ')}}",
+            ),
+        ],
+    )
+
+
+def test_coerce_array_argument():
+    array_arg = Argument(name="view_range", type="array", description="", required=False)
+    string_arg = Argument(name="path", type="string", description="", required=False)
+    # JSON-string-encoded array is parsed back into a list
+    assert _coerce_array_argument("[1, 50]", array_arg) == [1, 50]
+    # Actual lists pass through untouched
+    assert _coerce_array_argument([1, 50], array_arg) == [1, 50]
+    # Non-array-typed args are never coerced
+    assert _coerce_array_argument("[1, 50]", string_arg) == "[1, 50]"
+    # Unparseable / non-list values are returned unchanged
+    assert _coerce_array_argument("not json", array_arg) == "not json"
+    assert _coerce_array_argument("5", array_arg) == "5"
+
+
+def test_function_calling_parser_array_argument_as_string():
+    """Regression test for #1182: an array argument returned as a JSON string
+    must not be rendered character-by-character (e.g. ``[ 1 ,   5 0 ]``)."""
+    parser = FunctionCallingParser()
+    command = _view_range_command()
+
+    # The model returns view_range as a proper JSON array.
+    as_list = {
+        "message": "look",
+        "tool_calls": [
+            {
+                "function": {
+                    "name": "str_replace_editor",
+                    "arguments": '{"command": "view", "path": "/testbed/x.py", "view_range": [1, 50]}',
+                }
+            }
+        ],
+    }
+    _, action = parser(as_list, [command])
+    assert action == "str_replace_editor view /testbed/x.py --view_range 1 50"
+
+    # The model returns view_range as a JSON-encoded *string* (the #1182 case).
+    as_string = {
+        "message": "look",
+        "tool_calls": [
+            {
+                "function": {
+                    "name": "str_replace_editor",
+                    "arguments": '{"command": "view", "path": "/testbed/x.py", "view_range": "[1, 50]"}',
+                }
+            }
+        ],
+    }
+    _, action = parser(as_string, [command])
+    assert action == "str_replace_editor view /testbed/x.py --view_range 1 50"


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #1182

#### What does this implement/fix? Explain your changes.

Some models/providers return an `array`-typed tool-call argument as a **JSON-encoded string** (e.g. `"[1, 50]"`) instead of an actual JSON array (`[1, 50]`). Argument formats that use a Jinja `join` filter — e.g. `str_replace_editor`'s `view_range`:

```yaml
argument_format: "--view_range {{value|join(' ')}}"
```

then iterate that string **character by character**, producing broken commands. This is exactly the symptom in #1182:

```
str_replace_editor view /path --view_range [ 1 ,   5 0 ]
# -> argument --view_range: invalid int value: '['
```

Confirmed with Jinja directly: `{{ value|join(' ') }}` renders `[1, 50]` (list) → `1 50`, but `"[1, 50]"` (string) → `[ 1 ,   5 0 ]`.

**Fix (`sweagent/tools/parsing.py`):** add `_coerce_array_argument(value, argument)`, which — when the argument's declared `type` is `array` and the model supplied a JSON string encoding a list — parses it back into a list. Correctly-typed lists and non-array arguments pass through unchanged; unparseable strings are left as-is. It is applied before rendering in the three parsers that format arguments from structured input:

- `FunctionCallingParser` (the parser used in #1182)
- `XMLFunctionCallingParser`
- `JsonParser`

This **generalizes** the existing hard-coded `view_range`-only special-case already present in `XMLFunctionCallingParser` (which `json.loads`-es `view_range` by name) to *every* array argument across *all* parsers, keyed off the declared schema type rather than the argument name. The hard-coded block is left in place (it still provides a specific error message for malformed `view_range` in the XML path); coercing an already-parsed list is a no-op.

**Tests (`tests/test_parsing.py`):**

- `test_coerce_array_argument` — JSON-string arrays become lists; lists, non-array args, and unparseable strings are untouched.
- `test_function_calling_parser_array_argument_as_string` — a `view_range` argument returned as `[1, 50]` (list) *and* as `"[1, 50]"` (string) both render to `--view_range 1 50`.
