### PR TITLE
fix(tools): correct r2 command filter regex and multiline heredoc guard

### DIFF
--- a/sweagent/tools/tools.py
+++ b/sweagent/tools/tools.py
@@ -67,7 +67,7 @@ class ToolFilterConfig(BaseModel):
 
     block_unless_regex: dict[str, str] = {
         "radare2": r"\b(?:radare2)\b.*\s+-c\s+.*",
-        "r2": r"\b(?:radare2)\b.*\s+-c\s+.*",
+        "r2": r"\b(?:r2)\b.*\s+-c\s+.*",
     }
     """Block any command that matches one of these names unless it also matches the regex"""
 

--- a/sweagent/tools/utils.py
+++ b/sweagent/tools/utils.py
@@ -24,7 +24,11 @@ def _guard_multiline_input(action: str, match_fct: Callable[[str], re.Match | No
             if match_action.strip():
                 eof = first_match.group(3).strip()
                 if not match_action.split("\n")[0].strip().endswith(f"<< '{eof}'"):
-                    guarded_command = match_action[first_match.start() :]
+                    # `match_action` already starts at the matched command; slicing it
+                    # again by `first_match.start()` (an offset into `rem_action`) would
+                    # chop off the first characters of the command when it is preceded
+                    # by other content.
+                    guarded_command = match_action
                     first_line = guarded_command.split("\n")[0]
                     guarded_command = guarded_command.replace(first_line, first_line + f" << '{eof}'", 1)
                     parsed_action.append(guarded_command)

--- a/tests/test_tools_command_parsing.py
+++ b/tests/test_tools_command_parsing.py
@@ -1,6 +1,10 @@
+import re
+
 import pytest
 
 from sweagent.tools.commands import Argument, Command
+from sweagent.tools.tools import ToolConfig, ToolHandler
+from sweagent.tools.utils import _guard_multiline_input
 
 
 def test_command_parsing_formats():
@@ -191,3 +195,33 @@ def test_custom_argument_format():
 
     assert command.arguments[0].argument_format == "--{value}"
     assert command.invoke_format == "custom_format {arg1} "
+
+
+def test_r2_command_filter_allows_non_interactive_form():
+    """The default filter must allow `r2 -c ...` (its own allow-regex previously
+    hardcoded `radare2`, so the `r2` alias was always blocked)."""
+    handler = ToolHandler(ToolConfig())
+    # Non-interactive invocations are allowed for both the full name and the alias.
+    assert handler.should_block_action("r2 -c 'pd 10' /bin/ls") is False
+    assert handler.should_block_action("radare2 -c 'pd 10' /bin/ls") is False
+    # Interactive (no `-c`) invocations remain blocked.
+    assert handler.should_block_action("r2 /bin/ls") is True
+    assert handler.should_block_action("r2") is True
+
+
+def test_guard_multiline_input_preserves_first_line_after_preceding_content():
+    """A multi-line (heredoc) command that is preceded by other content must keep
+    its first line intact; previously the command was re-sliced and truncated."""
+    pattern = re.compile(r"^\s*(edit)\s*(.*?)^(end_of_edit)\s*$", re.DOTALL | re.MULTILINE)
+
+    def match_fct(action: str):
+        return pattern.search(action)
+
+    # Command at the start of the action already worked.
+    at_start = _guard_multiline_input("edit 5:10\nnew code\nend_of_edit", match_fct)
+    assert "edit 5:10 << 'end_of_edit'" in at_start
+
+    # Command preceded by other content used to lose the start of its first line.
+    with_prefix = _guard_multiline_input("ls -la\nedit 5:10\nnew code\nend_of_edit", match_fct)
+    assert "edit 5:10 << 'end_of_edit'" in with_prefix
+    assert with_prefix.startswith("ls -la")


### PR DESCRIPTION
#### Reference Issues/PRs

None (bugs found by inspection; no existing issue).

#### What does this implement/fix? Explain your changes.

Two independent correctness bugs in tool-command handling, each with a regression test.

**1. `r2` command filter always blocks the allowed non-interactive form (`sweagent/tools/tools.py`)**

`ToolFilterConfig.block_unless_regex` blocks a command *unless* the action also matches the regex. The `"r2"` entry's regex hardcoded the literal `radare2`:

```python
"radare2": r"\b(?:radare2)\b.*\s+-c\s+.*",
"r2":      r"\b(?:radare2)\b.*\s+-c\s+.*",   # <- requires "radare2", never matches "r2 ..."
```

`should_block_action` keys off the command name (`action.split()[0]`), so for an action starting with `r2` it looks up the `r2` regex, which requires the substring `radare2` (absent) → no match → the command is blocked. This is the **default** filter config, so `r2 -c "pd 10" /bin/ls` is always blocked even though the identical `radare2 -c ...` form is allowed. Fixed the `r2` entry to match `r2`.

**2. Multi-line heredoc guard truncates the command's first line when preceded by content (`sweagent/tools/utils.py`)**

In `_guard_multiline_input`, `match_action = rem_action[first_match.start():first_match.end()]` already begins at the matched command. It was then re-sliced:

```python
guarded_command = match_action[first_match.start():]
```

`first_match.start()` is an offset into `rem_action`, not into `match_action`. When the multi-line command is preceded by other content, `first_match.start() > 0`, so this chops the first `start()` characters off the command's first line, corrupting the heredoc. e.g. `"ls -la\nedit 5:10\nnew code\nend_of_edit"` became `"...\n10 << 'end_of_edit'\nnew code\nend_of_edit"` (the `edit 5:` prefix destroyed). When the command is at position 0 (the common case) `start()` is 0, which is why it went unnoticed. Fixed to use `match_action` directly.

**Tests (`tests/test_tools_command_parsing.py`):**
- `test_r2_command_filter_allows_non_interactive_form` — `r2 -c ...` / `radare2 -c ...` allowed; bare `r2` still blocked.
- `test_guard_multiline_input_preserves_first_line_after_preceding_content` — a heredoc command preceded by other content keeps its first line intact.
