### PR TITLE
fix(tools): repair undo_edit persistence and edit replace_all boolean parsing

### DIFF
--- a/tests/tools/test_edit_replace.py
+++ b/tests/tools/test_edit_replace.py
@@ -1,0 +1,22 @@
+from sweagent import TOOLS_DIR
+from tests.utils import make_python_tool_importable
+
+make_python_tool_importable(TOOLS_DIR / "windowed_edit_replace" / "bin" / "edit", "windowed_edit_replace_edit")
+import windowed_edit_replace_edit  # type: ignore  # noqa: E402
+
+
+def test_replace_all_argument_parsing():
+    """Regression test: `replace_all` used `type=bool`, and `bool("False")` is
+    `True`, so an explicit `replace-all=false` replaced every occurrence instead
+    of only the one in the displayed window."""
+    parse = windowed_edit_replace_edit.get_parser().parse_args
+    # Omitted -> default False (replace only within the window).
+    assert parse(["s", "r"]).replace_all is False
+    # Truthy spellings -> True.
+    assert parse(["s", "r", "True"]).replace_all is True
+    assert parse(["s", "r", "true"]).replace_all is True
+    assert parse(["s", "r", "1"]).replace_all is True
+    # Falsy spellings -> False (previously all parsed as True).
+    assert parse(["s", "r", "False"]).replace_all is False
+    assert parse(["s", "r", "false"]).replace_all is False
+    assert parse(["s", "r", "0"]).replace_all is False

--- a/tests/tools/test_str_replace_editor.py
+++ b/tests/tools/test_str_replace_editor.py
@@ -1,0 +1,50 @@
+"""End-to-end tests for the Anthropic `str_replace_editor` tool.
+
+The tool is a standalone script that persists state to the registry file between
+(separate-process) invocations, so we exercise it as a subprocess.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from sweagent import TOOLS_DIR
+
+EDITOR = TOOLS_DIR / "edit_anthropic" / "bin" / "str_replace_editor"
+REGISTRY_LIB = TOOLS_DIR / "registry" / "lib"
+
+
+def _run_editor(args: list[str], env_file: Path) -> subprocess.CompletedProcess:
+    env = dict(os.environ)
+    env["SWE_AGENT_ENV_FILE"] = str(env_file)
+    env["PYTHONPATH"] = str(REGISTRY_LIB) + os.pathsep + env.get("PYTHONPATH", "")
+    return subprocess.run(
+        [sys.executable, str(EDITOR), *args],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+def test_undo_edit_restores_previous_content(tmp_path):
+    """Regression test: file history was mutated on the object returned by the
+    `_file_history` getter, which never triggered the setter, so nothing was
+    persisted and `undo_edit` always failed with "No edit history found"."""
+    env_file = tmp_path / ".swe-agent-env"
+    env_file.write_text("{}")
+    target = tmp_path / "a.py"
+
+    r = _run_editor(["create", str(target), "--file_text", "x = 1\n"], env_file)
+    assert r.returncode == 0, r.stdout + r.stderr
+
+    r = _run_editor(["str_replace", str(target), "--old_str", "x = 1", "--new_str", "x = 2"], env_file)
+    assert r.returncode == 0, r.stdout + r.stderr
+    assert target.read_text() == "x = 2\n"
+
+    # Before the fix this exited 18 ("No edit history found") and left the file unchanged.
+    r = _run_editor(["undo_edit", str(target)], env_file)
+    assert r.returncode == 0, r.stdout + r.stderr
+    assert target.read_text() == "x = 1\n"

--- a/tools/edit_anthropic/bin/str_replace_editor
+++ b/tools/edit_anthropic/bin/str_replace_editor
@@ -361,6 +361,24 @@ class EditTool:
     def _file_history(self, value: dict):
         REGISTRY["file_history"] = json.dumps(value)
 
+    def _append_to_history(self, path: Path, content: str):
+        # Item-mutating the object returned by the `_file_history` getter never
+        # triggers the setter, so the appended history used to be discarded (and
+        # `undo_edit` always reported "No edit history"). Re-assign through the
+        # property to persist. Keys must be `str` since `Path` is not
+        # JSON-serializable.
+        history = self._file_history
+        history[str(path)].append(content)
+        self._file_history = history
+
+    def _pop_from_history(self, path: Path) -> Optional[str]:
+        history = self._file_history
+        if not history[str(path)]:
+            return None
+        content = history[str(path)].pop()
+        self._file_history = history
+        return content
+
     def __call__(
         self,
         *,
@@ -432,7 +450,7 @@ class EditTool:
             print("The parent directory {} does not exist. Please create it first.".format(path.parent))
             sys.exit(21)
         self.write_file(path, file_text)
-        self._file_history[path].append(file_text)
+        self._append_to_history(path, file_text)
         print("File created successfully at: {}".format(path))
 
     def view(self, path: Path, view_range: Optional[List[int]] = None):
@@ -574,7 +592,7 @@ class EditTool:
                 epilogue = LINT_WARNING_TEMPLATE.format(errors=errors)
 
         # Save the content to history
-        self._file_history[path].append(file_content)
+        self._append_to_history(path, file_content)
 
         # Create a snippet of the edited section
         replacement_line = file_content.split(old_str)[0].count("\n")
@@ -618,7 +636,7 @@ class EditTool:
         snippet = "\n".join(snippet_lines)
 
         self.write_file(path, new_file_text)
-        self._file_history[path].append(file_text)
+        self._append_to_history(path, file_text)
 
         # todo: Also expand these windows
 
@@ -633,11 +651,11 @@ class EditTool:
 
     def undo_edit(self, path: Path):
         """Implement the undo_edit command."""
-        if not self._file_history[path]:
+        old_text = self._pop_from_history(path)
+        if old_text is None:
             print("No edit history found for {}.".format(path))
             sys.exit(18)
 
-        old_text = self._file_history[path].pop()
         self.write_file(path, old_text)
 
         print("Last edit to {} undone successfully. {}".format(path, self._make_output(old_text, str(path))))

--- a/tools/windowed_edit_replace/bin/edit
+++ b/tools/windowed_edit_replace/bin/edit
@@ -76,11 +76,18 @@ DO NOT re-run the same failed edit command. Running it again will lead to the sa
 """
 
 
+def _str_to_bool(value: str) -> bool:
+    # `type=bool` applies `bool(str)`, which is True for any non-empty string,
+    # so `replace-all=False`/`false`/`0` would all be parsed as True and replace
+    # every occurrence instead of only the one in the window.
+    return str(value).strip().lower() in ("true", "1", "yes")
+
+
 def get_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser()
     parser.add_argument("search", type=str)
     parser.add_argument("replace", type=str)
-    parser.add_argument("replace_all", type=bool, nargs="?", default=False)
+    parser.add_argument("replace_all", type=_str_to_bool, nargs="?", default=False)
     return parser
 
 


### PR DESCRIPTION
#### Reference Issues/PRs

None (bugs found by inspection; no existing issue).

#### What does this implement/fix? Explain your changes.

Two independent correctness bugs in the editor tools that affect the agent's actual editing behavior. Each has a regression test.

**1. `undo_edit` never works in the Anthropic editor (`tools/edit_anthropic/bin/str_replace_editor`)**

`EditTool._file_history` is a `@property`: the getter rebuilds a `defaultdict` from the registry JSON on every access, and the *setter* is the only code that writes it back. Every edit recorded history with:

```python
self._file_history[path].append(content)
```

That item-mutates the throwaway dict returned by the getter and never triggers the setter, so nothing is persisted. Because each tool call runs as a separate process, the registry key stays `"{}"` forever and `undo_edit` always hits `if not self._file_history[path]:` → prints "No edit history found" and `sys.exit(18)`. Additionally the keys were `Path` objects (not JSON-serializable), so the setter would have raised `TypeError` had it ever been reached.

Fix: persist through the setter via small `_append_to_history` / `_pop_from_history` helpers that use `str(path)` keys.

Verified end-to-end (`create` → `str_replace` → `undo_edit`): before, the registry `file_history` stays `None` and undo exits 18 leaving the file edited; after, history is persisted and undo restores the previous content.

**2. `edit`'s `replace_all` treats an explicit `false` as `true` (`tools/windowed_edit_replace/bin/edit`)**

```python
parser.add_argument("replace_all", type=bool, nargs="?", default=False)
```

`type=bool` applies `bool(str)` to the raw argument, and every non-empty string is truthy. The `replace-all` argument is declared `type: boolean`, so when the model passes `replace-all: false` it is rendered to the literal string `"False"`, and `bool("False")` is `True` → the tool replaces **every** occurrence in the file instead of only the one in the displayed window (potentially corrupting unintended lines). Omitting the argument (default `False`) and passing `true` both happen to work; only an explicit false is broken, which is a natural model action.

Fix: parse truthy spellings (`true`/`1`/`yes`, case-insensitive) explicitly.

**Tests:**
- `tests/tools/test_str_replace_editor.py` — end-to-end subprocess test that create → str_replace → undo_edit restores the pre-edit content.
- `tests/tools/test_edit_replace.py` — `replace_all` argument parsing: omitted/false/False/0 → `False`, true/True/1 → `True`.
