### PR TITLE
fix(env): map check="ignore" to swerex "ignore" to skip exit-code extraction

### DIFF
--- a/sweagent/environment/swe_env.py
+++ b/sweagent/environment/swe_env.py
@@ -216,7 +216,11 @@ class SWEEnv:
             output: output from container
         """
         self.logger.log(logging.TRACE, "Input:\n%s", input)  # type: ignore
-        rex_check = "silent" if check else "ignore"
+        # `check` is always a non-empty (truthy) string, so `"silent" if check`
+        # always selected "silent" and swerex always extracted the exit code.
+        # Only extract it when we actually use it (`warn`/`raise`); `ignore` maps
+        # to swerex's `ignore`, which skips extraction (more stable).
+        rex_check = "ignore" if check == "ignore" else "silent"
         r = asyncio.run(
             self.deployment.runtime.run_in_session(BashAction(command=input, timeout=timeout, check=rex_check))
         )

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -64,3 +64,27 @@ def test_env_communicate_with_handling_timeout(test_env_args):
 def test_env_interrupt_session(test_env_args):
     with swe_env_context(test_env_args) as env:
         env.interrupt_session()
+
+
+@pytest.mark.parametrize(
+    ("check", "expected_rex_check"),
+    [("ignore", "ignore"), ("warn", "silent"), ("raise", "silent")],
+)
+def test_communicate_maps_check_to_rex_check(check, expected_rex_check):
+    """`check="ignore"` must reach swerex as `ignore` (skip exit-code extraction);
+    previously `"silent" if check` always selected `silent` since `check` is a
+    non-empty string."""
+    from sweagent.environment.swe_env import SWEEnv
+
+    captured = {}
+
+    async def fake_run_in_session(action):
+        captured["check"] = action.check
+        return mock.Mock(output="", exit_code=0)
+
+    deployment = mock.MagicMock()
+    deployment.runtime.run_in_session = fake_run_in_session
+    env = SWEEnv(deployment=deployment, repo=None, post_startup_commands=[])
+
+    env.communicate("echo 'hello world'", check=check)
+    assert captured["check"] == expected_rex_check


### PR DESCRIPTION
#### Reference Issues/PRs

None (bug found by inspection; no existing issue).

#### What does this implement/fix? Explain your changes.

`SWEEnv.communicate` (`sweagent/environment/swe_env.py`) chooses how swerex should handle the command's exit code:

```python
rex_check = "silent" if check else "ignore"
```

`check` is a `Literal["warn", "ignore", "raise"]`, i.e. always a non-empty (truthy) string, so this expression **always** evaluates to `"silent"` and the `"ignore"` branch is dead code. swerex's `BashAction.check` values are: `silent` (extract the exit code, don't raise), `ignore` (do **not** extract the exit code), `raise` (extract and raise). So the intended behavior — documented in the `communicate` docstring as `ignore: do not extract exit code (more stable)` — never happens: swerex runs the exit-code extraction on **every** agent command, even in the "more stable" `ignore` mode.

This is the mode used on the main agent command path (`env.communicate(..., check="ignore")`), so the stability optimization was inert for essentially every action.

Fix:

```python
rex_check = "ignore" if check == "ignore" else "silent"
```

`ignore` → swerex `ignore` (skip extraction); `warn`/`raise` → swerex `silent` (extract without swerex raising; SWE-agent already does its own non-zero handling right below via `if check != "ignore" and r.exit_code != 0`).

**Test (`tests/test_env.py`):** `test_communicate_maps_check_to_rex_check` mocks the runtime and asserts the `BashAction.check` that reaches swerex is `ignore` for `check="ignore"` and `silent` for `warn`/`raise`.
