### PR TITLE
fix(tools): pass a 1-based flake8 window in windowed_edit_linting

### DIFF
--- a/tests/tools/test_edit_linting.py
+++ b/tests/tools/test_edit_linting.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import json
+from unittest import mock
+
+from sweagent import TOOLS_DIR
+from tests.utils import make_python_tool_importable
+
+make_python_tool_importable(TOOLS_DIR / "windowed_edit_linting" / "bin" / "edit", "windowed_edit_linting_edit")
+import windowed_edit_linting_edit  # type: ignore  # noqa: E402
+
+
+def _setup_file(env_file, content: str):
+    test_path = env_file.parent / "test.py"
+    test_path.write_text(content)
+    env_file.write_text(json.dumps({"CURRENT_FILE": str(test_path), "FIRST_LINE": "0", "WINDOW": "50"}))
+    return test_path
+
+
+def test_preexisting_error_above_edit_does_not_revert(with_tmp_env_file):
+    """Regression test: the flake8 filter window was passed 0-based while flake8
+    line numbers are 1-based, so a pre-existing error on the line directly above
+    the edited region was misclassified as newly introduced and the (valid) edit
+    was reverted."""
+    # 15-line file; the (mocked) pre-existing lint error lives on 1-based line 4,
+    # i.e. directly above the 1-based lines 5-10 that we edit.
+    path = _setup_file(with_tmp_env_file, "\n".join(f"line{i}" for i in range(1, 16)) + "\n")
+    preexisting = f"{path}:4:1: F821 undefined name 'x'"
+
+    # flake8 returns the same pre-existing error before and after the edit.
+    with mock.patch.object(windowed_edit_linting_edit, "flake8", return_value=preexisting):
+        windowed_edit_linting_edit.main("5:10", "REPLACED")
+
+    # The edit must have been applied rather than reverted by a bogus lint error.
+    assert "REPLACED" in path.read_text()

--- a/tools/windowed_edit_linting/bin/edit
+++ b/tools/windowed_edit_linting/bin/edit
@@ -102,7 +102,10 @@ def main(line_range: str, replacement_text: Union[str, None] = None):
     new_flake8_output = format_flake8_output(
         post_edit_lint,
         previous_errors_string=pre_edit_lint,
-        replacement_window=(start_line, end_line),
+        # `start_line`/`end_line` are 0-based, but `format_flake8_output` compares
+        # the window against flake8's 1-based line numbers. Pass a 1-based window
+        # so a pre-existing error just above the edit isn't misread as new.
+        replacement_window=(start_line + 1, end_line + 1),
         replacement_n_lines=len(replacement_text.splitlines()),
     )
 


### PR DESCRIPTION
#### Reference Issues/PRs

None (bug found by inspection; no existing issue).

#### What does this implement/fix? Explain your changes.

`tools/windowed_edit_linting/bin/edit` reverts an edit when it thinks the edit introduced new lint errors, filtering out pre-existing errors via `format_flake8_output(..., replacement_window=...)`. `format_flake8_output` compares the window against `Flake8Error.line_number`, which is **1-based** (flake8 output). This contract is what the existing `tests/tools/test_split_string.py` encodes (e.g. `replacement_window=(12, 13)` with an error on line 12).

But `edit` builds the window from `parse_line_range`, which returns **0-based** indices (`start - 1, end - 1`) for the in-window edit, and passes those same 0-based values as the `replacement_window`:

```python
start_line, end_line = parse_line_range(line_range)   # 0-based
...
replacement_window=(start_line, end_line),            # 0-based, but the callee expects 1-based
```

Because of the off-by-one, a pre-existing lint error on the line **directly above** the edited region (1-based line `start`) falls *inside* the shifted window `[start-1, end-1]`, so it is dropped from the ignore-list, reported as newly introduced, and the valid edit is reverted with a bogus syntax-error message.

Fix: pass a 1-based window `(start_line + 1, end_line + 1)`.

**Test (`tests/tools/test_edit_linting.py`):** end-to-end regression test — a 15-line file with a (mocked) pre-existing flake8 error on line 4, editing 1-based lines 5-10. Before the fix the edit is reverted (`exit(1)`); after, it is applied. Verified it fails on the unpatched script and passes on the patched one.

**Note:** the same 0-based-window-vs-1-based-line-numbers off-by-one exists in the other windowed edit tools that pass a `replacement_window` (`windowed_edit_replace/bin/edit` and `bin/insert`, `windowed_edit_rewrite/bin/edit`), which build the window from `ReplacementInfo.first_replaced_line` / `InsertInfo.first_inserted_line` / `WindowedFile.line_range` (all 0-based). I kept this PR focused on `windowed_edit_linting` (the lint-gate tool) with a clean end-to-end test; happy to follow up on the others with equivalent tests if you'd like them in the same PR.
