### PR TITLE
fix(reviewer): let cost-limit errors abort the chooser

### DIFF
--- a/sweagent/agent/reviewer.py
+++ b/sweagent/agent/reviewer.py
@@ -21,6 +21,7 @@ from sweagent.agent.models import (
     get_model,
 )
 from sweagent.agent.problem_statement import ProblemStatement
+from sweagent.exceptions import CostLimitExceededError
 from sweagent.tools.parsing import ActionParser
 from sweagent.tools.tools import ToolConfig
 from sweagent.types import AgentInfo, Trajectory, TrajectoryStep
@@ -339,6 +340,9 @@ class Chooser:
             preselector = Preselector(self.config.preselector)
             try:
                 preselector_output = preselector.choose(problem_statement, [input[i] for i in selected_indices])
+            except CostLimitExceededError:
+                # A cost limit must stop the run, so it may not be absorbed here.
+                raise
             except Exception as e:
                 self.logger.critical(f"Preselector failed: {e}", exc_info=True)
                 preselector_output = None
@@ -356,9 +360,15 @@ class Chooser:
                 self.logger.error("Preselector must have failed, ignoring it.")
         messages = self.build_messages(problem_statement, [input[i] for i in selected_indices])
         chosen_idx = None
+        # Assigned up front: the fallback below still reports the response, and a
+        # failed query must not turn into an UnboundLocalError there.
+        response = ""
         try:
             response = self.model.query(messages)["message"]  # type: ignore
             chosen_idx = self.interpret(response)
+        except CostLimitExceededError:
+            # A cost limit must stop the run, so it may not be absorbed here.
+            raise
         except Exception as e:
             self.logger.critical(f"Chooser failed: {e}", exc_info=True)
             chosen_idx = None
@@ -427,6 +437,9 @@ class Reviewer(AbstractReviewer):
         for _ in range(self._config.n_sample):
             try:
                 answer = self._model.query(messages)["message"]
+            except CostLimitExceededError:
+                # A cost limit must stop the run, so it may not be absorbed here.
+                raise
             except Exception as e:
                 self.logger.warning(f"Query failed: {e}", exc_info=True)
                 continue

--- a/tests/test_reviewer.py
+++ b/tests/test_reviewer.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import pytest
+
+from sweagent.agent.models import AbstractModel, GenericAPIModelConfig, InstanceStats
+from sweagent.agent.reviewer import (
+    Chooser,
+    ChooserConfig,
+    Preselector,
+    PreselectorConfig,
+    ReviewSubmission,
+)
+from sweagent.exceptions import (
+    InstanceCostLimitExceededError,
+    TotalCostLimitExceededError,
+)
+from sweagent.utils.log import get_logger
+
+
+class _RaisingModel(AbstractModel):
+    """A model whose every query fails with a fixed exception."""
+
+    def __init__(self, exc: Exception):
+        self._exc = exc
+
+    def query(self, *args, **kwargs):
+        raise self._exc
+
+    @property
+    def stats(self) -> InstanceStats:
+        return InstanceStats()
+
+
+class _ConstantModel(AbstractModel):
+    """A model that always answers with the same message."""
+
+    def __init__(self, message: str):
+        self._message = message
+
+    def query(self, *args, **kwargs):
+        return {"message": self._message}
+
+    @property
+    def stats(self) -> InstanceStats:
+        return InstanceStats()
+
+
+def _chooser(model: AbstractModel, *, preselector: PreselectorConfig | None = None) -> Chooser:
+    config = ChooserConfig(
+        model=GenericAPIModelConfig(name="test-model"),
+        system_template="system",
+        instance_template="instance {{problem_statement}}",
+        submission_template="submission {{submission}}",
+        preselector=preselector,
+    )
+    # Bypass __init__ so that no real model is instantiated.
+    chooser = object.__new__(Chooser)
+    chooser.config = config
+    chooser.logger = get_logger("test-chooser")
+    chooser.model = model
+    return chooser
+
+
+def _submission() -> ReviewSubmission:
+    return ReviewSubmission(
+        submission="solution text",
+        trajectory=[],
+        info={"exit_status": "submitted", "submission": "solution text", "model_stats": {}},
+        model_stats=InstanceStats(),
+    )
+
+
+@pytest.mark.parametrize("exc_type", [TotalCostLimitExceededError, InstanceCostLimitExceededError])
+def test_chooser_propagates_cost_limit_errors(exc_type):
+    """A cost limit hit by the chooser model must abort, not be swallowed."""
+    chooser = _chooser(_RaisingModel(exc_type("cost limit")))
+    with pytest.raises(exc_type):
+        chooser.choose("problem statement", [_submission(), _submission()])
+
+
+def test_chooser_falls_back_when_query_fails():
+    """Any other query failure keeps the graceful fallback (no UnboundLocalError)."""
+    chooser = _chooser(_RaisingModel(RuntimeError("boom")))
+    output = chooser.choose("problem statement", [_submission(), _submission()])
+    assert output.chosen_idx == 0
+    assert output.response == ""
+
+
+def test_chooser_returns_chosen_index():
+    chooser = _chooser(_ConstantModel("I choose submission 1"))
+    output = chooser.choose("problem statement", [_submission(), _submission()])
+    assert output.chosen_idx == 1
+
+
+@pytest.mark.parametrize("exc_type", [TotalCostLimitExceededError, InstanceCostLimitExceededError])
+def test_preselector_cost_limit_propagates_through_chooser(exc_type, monkeypatch):
+    """The same holds for a cost limit raised by the preselector model."""
+    preselector_config = PreselectorConfig(
+        model=GenericAPIModelConfig(name="test-model"),
+        system_template="system",
+        instance_template="instance {{problem_statement}}",
+        submission_template="submission {{submission}}",
+    )
+
+    def _fake_init(self, config):
+        self.config = config
+        self.logger = get_logger("test-preselector")
+        self.model = _RaisingModel(exc_type("cost limit"))
+
+    monkeypatch.setattr(Preselector, "__init__", _fake_init)
+    chooser = _chooser(_ConstantModel("I choose submission 0"), preselector=preselector_config)
+    with pytest.raises(exc_type):
+        chooser.choose("problem statement", [_submission(), _submission(), _submission()])


### PR DESCRIPTION
Fixes #1491.

## The bug

`Chooser.choose` wraps `self.model.query()` in a bare `except Exception`. `TotalCostLimitExceededError` and `InstanceCostLimitExceededError` both derive from `CostLimitExceededError`, so a cost-limit breach raised by the chooser (or preselector) model is absorbed and the run carries on — even though `agents.py` re-raises `TotalCostLimitExceededError` and exits with `exit_cost` for the rest, and the comment there says "Need to make sure that this error causes everything to stop".

Second defect on the same path: the fallback `return ChooserOutput(..., response=response, ...)` reads `response`, which is only assigned inside the `try`. So *any* failing query raised `UnboundLocalError` rather than falling back gracefully; the caller then caught that generically and pinned `best_attempt_idx = 0`.

## The change

- Re-raise `CostLimitExceededError` ahead of the generic handler in `Chooser.choose` (both the preselector call and the chooser query) and in the `Reviewer` n-sample loop.
- Assign `response = ""` before the query so the fallback return is well-defined.

No caller changes: `agents.py` already re-raises `TotalCostLimitExceededError` from `get_best()`.

## Evidence

New `tests/test_reviewer.py`, 6 tests. Against the unpatched `reviewer.py` (`git stash` of just that file) 5 of them fail:

```
FAILED tests/test_reviewer.py::test_chooser_propagates_cost_limit_errors[TotalCostLimitExceededError]
FAILED tests/test_reviewer.py::test_chooser_propagates_cost_limit_errors[InstanceCostLimitExceededError]
FAILED tests/test_reviewer.py::test_chooser_falls_back_when_query_fails - Unb...
FAILED tests/test_reviewer.py::test_preselector_cost_limit_propagates_through_chooser[TotalCostLimitExceededError]
FAILED tests/test_reviewer.py::test_preselector_cost_limit_propagates_through_chooser[InstanceCostLimitExceededError]
5 failed, 1 passed
```

With the fix: `6 passed`. `ruff check` and `ruff format --check` are clean on both files.

One thing I left alone: `InstanceCostLimitExceededError` now propagates as far as the existing generic handler in `RetryAgent.get_trajectory_data`, which still pins index 0 rather than aborting. Making that fatal too looked like a bigger behavioural call than the issue asked for — happy to extend it if you'd prefer.