### PR TITLE
fix(inspector): reject off-directory trajectory paths, bind to loopback, drop wildcard CORS

### DIFF
--- a/docs/usage/inspector.md
+++ b/docs/usage/inspector.md
@@ -59,6 +59,9 @@ The inspector will then be launched in the browser:
 
 - `--directory`: Directory of trajectories to inspect (Defaults to current directory)
 - `--port`: Port to host web app (Defaults to `8000`).
+- `--host`: Interface to bind to (Defaults to `127.0.0.1`). Trajectories can contain
+  secrets from the environment or the solved repository, so the inspector only listens
+  on loopback; pass `0.0.0.0` to expose it on the network deliberately.
 
 ## Benchmark results
 

--- a/sweagent/inspector/server.py
+++ b/sweagent/inspector/server.py
@@ -8,8 +8,29 @@ from argparse import ArgumentParser
 from functools import partial
 from pathlib import Path
 from typing import Any
+from urllib.parse import unquote, urlsplit
 
 import yaml
+
+
+def resolve_trajectory_path(traj_dir: str | Path, file_path: str) -> Path:
+    """Resolve a requested trajectory path against the served directory.
+
+    ``/trajectory/`` is handled before ``SimpleHTTPRequestHandler`` gets a chance to
+    sanitize the path, so the ``..`` rejection has to happen here: without it a
+    request with literal parent segments reads trajectory files from anywhere on
+    the host.  Absolute paths are rejected for the same reason.
+
+    Raises:
+        FileNotFoundError: if the request escapes ``traj_dir``.
+    """
+    requested = unquote(urlsplit(file_path).path)
+    root = Path(traj_dir).resolve()
+    candidate = (root / requested).resolve()
+    if candidate != root and root not in candidate.parents:
+        msg = f"File {file_path} not found"
+        raise FileNotFoundError(msg)
+    return candidate
 
 
 def add_problem_statement(content):
@@ -240,7 +261,7 @@ class Handler(http.server.SimpleHTTPRequestHandler):
     def serve_file_content(self, file_path):
         try:
             content = load_content(
-                Path(self.traj_dir) / file_path,
+                resolve_trajectory_path(self.traj_dir, file_path),
                 self.gold_patches,
                 self.test_patches,
             )

--- a/sweagent/inspector/server.py
+++ b/sweagent/inspector/server.py
@@ -308,12 +308,8 @@ class Handler(http.server.SimpleHTTPRequestHandler):
             self.send_response(204)  # Send no content response if no update
         self.end_headers()
 
-    def end_headers(self):
-        self.send_header("Access-Control-Allow-Origin", "*")
-        super().end_headers()
 
-
-def main(data_path, directory, port):
+def main(data_path, directory, port, host="127.0.0.1"):
     data = []
     if data_path is not None:
         if data_path.endswith(".jsonl"):
@@ -340,8 +336,8 @@ def main(data_path, directory, port):
         test_patches=test_patches,
     )
     try:
-        with socketserver.TCPServer(("", port), handler_with_directory) as httpd:
-            print(f"Serving at http://localhost:{port}")
+        with socketserver.TCPServer((host, port), handler_with_directory) as httpd:
+            print(f"Serving at http://{host}:{port}")
             httpd.serve_forever()
     except OSError as e:
         if e.errno == 48:
@@ -359,6 +355,12 @@ def get_parser():
     )
     parser.add_argument("--directory", type=str, help="Directory to serve", default=os.getcwd(), nargs="?")
     parser.add_argument("--port", type=int, help="Port to serve", default=8000)
+    parser.add_argument(
+        "--host",
+        type=str,
+        help="Interface to bind to. Defaults to loopback; pass 0.0.0.0 to expose the inspector on the network.",
+        default="127.0.0.1",
+    )
     return parser
 
 

--- a/tests/test_inspector_server.py
+++ b/tests/test_inspector_server.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import pytest
+
+from sweagent.inspector.server import resolve_trajectory_path
+
+
+@pytest.fixture
+def traj_dir(tmp_path):
+    served = tmp_path / "served"
+    (served / "nested").mkdir(parents=True)
+    (served / "run.traj").write_text("{}")
+    (served / "nested" / "run.traj").write_text("{}")
+    (tmp_path / "secret.json").write_text('{"secret": "value"}')
+    return served
+
+
+@pytest.mark.parametrize("name", ["run.traj", "nested/run.traj", "nested%2Frun.traj"])
+def test_paths_inside_the_directory_resolve(traj_dir, name):
+    resolved = resolve_trajectory_path(traj_dir, name)
+    assert resolved.is_file()
+    assert traj_dir.resolve() in resolved.parents
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "../secret.json",
+        "nested/../../secret.json",
+        "..%2Fsecret.json",
+        "../../../../../../etc/passwd",
+    ],
+)
+def test_parent_segments_are_rejected(traj_dir, name):
+    with pytest.raises(FileNotFoundError):
+        resolve_trajectory_path(traj_dir, name)
+
+
+def test_absolute_paths_are_rejected(traj_dir, tmp_path):
+    with pytest.raises(FileNotFoundError):
+        resolve_trajectory_path(traj_dir, str(tmp_path / "secret.json"))
+
+
+def test_query_string_is_stripped(traj_dir):
+    assert resolve_trajectory_path(traj_dir, "run.traj?cache=0").is_file()


### PR DESCRIPTION
Fixes #1472.

## The bug

`do_GET` handles `/trajectory/` itself before delegating to `SimpleHTTPRequestHandler`, so that route never sees the built-in `..` sanitization and `Path(self.traj_dir) / file_path` resolves wherever the request points. Combined with the `("", port)` bind (all interfaces) and the unconditional `Access-Control-Allow-Origin: *`, an unauthenticated client — or any web page the user visits — can read trajectory-shaped JSON from outside the served directory. Trajectories carry command output and environment secrets.

## The change

Three commits:

1. `resolve_trajectory_path()` resolves the request against the served directory and raises `FileNotFoundError` (→ existing 404 handler) for anything that escapes it. Percent-encoded segments are decoded first and the query string stripped, so `..%2F` and `?cache=0` are handled too.
2. Regression tests for that helper.
3. Bind `127.0.0.1` by default with a new `--host` flag for the deliberate network case, and remove the wildcard CORS header — the UI is same-origin and never needed it.

## Evidence

Live server, unpatched `server.py` (`git stash` of just that file), same fixtures:

```
bind: *:8233
traversal on main: 200
Access-Control-Allow-Origin: *
```

Same fixtures with the patch:

```
bind: 127.0.0.1:8232
in-dir:            200
traversal:         404
encoded traversal: 404
absolute:          404
CORS header:       (none)
```

`tests/test_inspector_server.py`: 9 passed. `ruff check` / `ruff format --check` clean.

Two judgement calls worth flagging, both easy to change: the loopback default breaks anyone who runs `sweagent inspector` on a remote box and browses to it — hence `--host 0.0.0.0` and a docs note rather than a hard block. And I removed the CORS header outright instead of narrowing it to localhost, since nothing in the shipped UI is cross-origin.