### PR TITLE
fix(models): retry one sample at a time under n>1 sampling

### DIFF
--- a/sweagent/agent/models.py
+++ b/sweagent/agent/models.py
@@ -780,29 +780,23 @@ class LiteLLMModel(AbstractModel):
         self._update_stats(input_tokens=input_tokens, output_tokens=output_tokens, cost=cost)
         return outputs
 
-    def _query(
-        self, messages: list[dict[str, str]], n: int | None = None, temperature: float | None = None
-    ) -> list[dict]:
-        if n is None:
-            return self._single_query(messages, temperature=temperature)
-        outputs = []
-        # not needed for openai, but oh well.
-        for _ in range(n):
-            outputs.extend(self._single_query(messages))
-        return outputs
+    def _retrying_single_query(self, messages: list[dict[str, str]], temperature: float | None = None) -> list[dict]:
+        """Run one sample, retrying transient failures.
 
-    def query(self, history: History, n: int = 1, temperature: float | None = None) -> list[dict] | dict:
-        messages = self._history_to_messages(history)
+        The retry sits around a *single* sample rather than around the whole
+        `n`-sample batch: a sample that already completed has been paid for, and
+        re-issuing it because a later sample failed bills it twice.
+        """
 
         def retry_warning(retry_state: RetryCallState):
             exception_info = ""
-            if attempt.retry_state.outcome is not None and attempt.retry_state.outcome.exception() is not None:
-                exception = attempt.retry_state.outcome.exception()
+            if retry_state.outcome is not None and retry_state.outcome.exception() is not None:
+                exception = retry_state.outcome.exception()
                 exception_info = f" due to {exception.__class__.__name__}: {str(exception)}"
 
             self.logger.warning(
-                f"Retrying LM query: attempt {attempt.retry_state.attempt_number} "
-                f"(slept for {attempt.retry_state.idle_for:.2f}s)"
+                f"Retrying LM query: attempt {retry_state.attempt_number} "
+                f"(slept for {retry_state.idle_for:.2f}s)"
                 f"{exception_info}"
             )
 
@@ -832,7 +826,23 @@ class LiteLLMModel(AbstractModel):
             before_sleep=retry_warning,
         ):
             with attempt:
-                result = self._query(messages, n=n, temperature=temperature)
+                result = self._single_query(messages, temperature=temperature)
+        return result
+
+    def _query(
+        self, messages: list[dict[str, str]], n: int | None = None, temperature: float | None = None
+    ) -> list[dict]:
+        if n is None:
+            return self._retrying_single_query(messages, temperature=temperature)
+        outputs = []
+        # not needed for openai, but oh well.
+        for _ in range(n):
+            outputs.extend(self._retrying_single_query(messages, temperature=temperature))
+        return outputs
+
+    def query(self, history: History, n: int = 1, temperature: float | None = None) -> list[dict] | dict:
+        messages = self._history_to_messages(history)
+        result = self._query(messages, n=n, temperature=temperature)
         if n is None or n == 1:
             return result[0]
         return result

--- a/tests/test_model_sampling.py
+++ b/tests/test_model_sampling.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import litellm
+import pytest
+
+from sweagent.agent.models import GenericAPIModelConfig, LiteLLMModel, RetryConfig
+from sweagent.tools.parsing import ActionParser
+from sweagent.tools.tools import ToolConfig
+
+
+def _fake_response():
+    message = type(
+        "M",
+        (),
+        {"content": "action: no_action", "tool_calls": None, "thinking_blocks": None},
+    )()
+    choice = type("C", (), {"message": message, "finish_reason": "stop"})()
+    usage = type("U", (), {"prompt_tokens": 100, "completion_tokens": 10, "total_tokens": 110})()
+    return type("R", (), {"choices": [choice], "usage": usage, "model": "gpt-4o"})()
+
+
+@pytest.fixture
+def model():
+    model = LiteLLMModel(
+        GenericAPIModelConfig(
+            name="gpt-4o",
+            api_key="dummy",
+            retry=RetryConfig(retries=2, min_wait=0.01, max_wait=0.02),
+            per_instance_cost_limit=0,
+            total_cost_limit=0,
+        ),
+        ToolConfig(parse_function=ActionParser()),
+    )
+    model._history_to_messages = lambda history: [{"role": "user", "content": "test"}]
+    return model
+
+
+def test_failed_sample_does_not_rebill_earlier_samples(model):
+    """A retryable failure on sample 2 must not re-issue sample 1."""
+    calls = []
+
+    def fake_completion(*args, **kwargs):
+        calls.append(kwargs)
+        if len(calls) == 2:
+            msg = "rate limited"
+            raise litellm.exceptions.RateLimitError(message=msg, llm_provider="openai", model="gpt-4o")
+        return _fake_response()
+
+    with patch("litellm.completion", side_effect=fake_completion):
+        outputs = model.query(None, n=2)
+
+    assert len(outputs) == 2
+    # 3 real calls: sample 1, sample 2 (rate limited), sample 2 again.  Sample 1
+    # is not re-issued, so it is billed exactly once.
+    assert len(calls) == 3
+    assert model.stats.api_calls == 2
+
+
+def test_explicit_temperature_reaches_the_provider(model):
+    """`temperature=` overrides are documented (comparison_temperature) - honour them."""
+    calls = []
+
+    def fake_completion(*args, **kwargs):
+        calls.append(kwargs)
+        return _fake_response()
+
+    with patch("litellm.completion", side_effect=fake_completion):
+        model.query(None, temperature=0.75)
+        model.query(None, n=2, temperature=0.25)
+
+    assert [call["temperature"] for call in calls] == [0.75, 0.25, 0.25]


### PR DESCRIPTION
Fixes #1492.

## The bug

`query()` wraps `self._query(messages, n=n)` — the whole batch — in the tenacity retry. `_query` bills each sample in `_update_stats` as soon as it returns, and nothing rolls that back, so when sample *k* raises something retryable (`RateLimitError`, `Timeout` and `APIConnectionError` are all retried — only `APIError` and friends are excluded) the retry re-issues samples 1..k-1 as fresh `litellm.completion` calls. That is real money, not just bookkeeping: with the default `retries=20` and `BinaryTrajectoryComparison` (n up to 10), a persistent rate limit at the tail of a batch can bill the prefix many times over.

## The change

Narrow the retry's scope instead of adding rollback: `_retrying_single_query` wraps one `_single_query`, and `_query` calls it once per sample. Retry policy, budget, exclusion list and warning text are all unchanged.

One extra line, called out because it isn't in the issue: `temperature` is now forwarded on the n-sample branch. It was dropped there, and since `query()` defaults to `n=1` that branch is the *normal* path — so `BinaryTrajectoryComparison.comparison_temperature` ("Override the model's temperature", `action_sampler.py:288`) never reached the provider. Happy to split that out if you'd rather have it separate.

## Evidence

`tests/test_model_sampling.py`, using the issue's fake-`litellm.completion` harness. Against the unpatched `models.py` (`git stash` of just that file):

```
>       assert len(calls) == 3
E       AssertionError: assert 4 == 3
>       assert [call["temperature"] for call in calls] == [0.75, 0.25, 0.25]
E       assert [0.0, 0.0, 0.0] == [0.75, 0.25, 0.25]
2 failed
```

With the fix: `2 passed` — 3 provider calls for 2 samples (sample 1 once, sample 2 twice) and `stats.api_calls == 2`. Existing `tests/test_models.py` still passes (4 passed); `ruff check` / `ruff format --check` clean.