### PR TITLE
fix(reviewer): report the chooser's cost in ChooserRetryLoop stats

### DIFF
--- a/sweagent/agent/reviewer.py
+++ b/sweagent/agent/reviewer.py
@@ -294,7 +294,18 @@ class Chooser:
         self.config = config
         self.model = get_model(config.model, ToolConfig(parse_function=ActionParser()))
         self.logger = get_logger("chooser", emoji="🧠")
+        # Kept on the instance rather than built per call so that its spend is
+        # still readable through `stats` after `choose` returns.
+        self._preselector: Preselector | None = None
         # self.summarizer = Summarizer(config.summarizer, self.model) if config.summarizer else None
+
+    @property
+    def stats(self) -> InstanceStats:
+        """Everything this chooser spent, preselector included."""
+        stats = self.model.stats
+        if self._preselector is not None:
+            stats = stats + self._preselector.model.stats
+        return stats
 
     def interpret(self, response: str) -> int:
         # Use regex to extract the last number of the response
@@ -336,7 +347,9 @@ class Chooser:
         else:
             self.logger.debug(f"Got only {n_submitted} submitted submissions, disabling exit status filtering")
         if self.config.preselector and len(selected_indices) > 2:
-            preselector = Preselector(self.config.preselector)
+            if self._preselector is None:
+                self._preselector = Preselector(self.config.preselector)
+            preselector = self._preselector
             try:
                 preselector_output = preselector.choose(problem_statement, [input[i] for i in selected_indices])
             except Exception as e:
@@ -508,11 +521,14 @@ class ChooserRetryLoop(AbstractRetryLoop):
 
     @property
     def _total_stats(self) -> InstanceStats:
-        return sum((s.model_stats for s in self._submissions), start=InstanceStats())
+        # The chooser only runs in `get_best()`, after the retry loop has ended,
+        # so folding it in here reports its spend without changing the budget
+        # decisions in `retry()` - where it is still zero.
+        return sum((s.model_stats for s in self._submissions), start=InstanceStats()) + self._chooser.stats
 
     @property
     def review_model_stats(self) -> InstanceStats:
-        return InstanceStats()
+        return self._chooser.stats
 
     @property
     def _n_attempts(self) -> int:

--- a/tests/test_chooser_retry_loop.py
+++ b/tests/test_chooser_retry_loop.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import pytest
+
+from sweagent.agent.models import GenericAPIModelConfig, InstanceStats
+from sweagent.agent.problem_statement import TextProblemStatement
+from sweagent.agent.reviewer import (
+    ChooserConfig,
+    ChooserRetryLoopConfig,
+    PreselectorConfig,
+    ReviewSubmission,
+)
+
+
+def _model_config() -> GenericAPIModelConfig:
+    return GenericAPIModelConfig(name="test-model", api_key="dummy")
+
+
+def _loop_config(*, with_preselector: bool = False) -> ChooserRetryLoopConfig:
+    return ChooserRetryLoopConfig(
+        chooser=ChooserConfig(
+            model=_model_config(),
+            system_template="pick",
+            instance_template="{{problem_statement}}",
+            submission_template="{{submission}}",
+            preselector=PreselectorConfig(
+                model=_model_config(),
+                system_template="preselect",
+                instance_template="{{problem_statement}}",
+                submission_template="{{submission}}",
+            )
+            if with_preselector
+            else None,
+        ),
+        max_attempts=10,
+        min_budget_for_new_attempt=1.0,
+        cost_limit=6.0,
+    )
+
+
+def _submission(cost: float) -> ReviewSubmission:
+    return ReviewSubmission(
+        trajectory=[],
+        info={"submission": "pass", "exit_status": "submitted"},
+        model_stats=InstanceStats(instance_cost=cost, api_calls=1),
+    )
+
+
+def test_chooser_cost_is_reported():
+    loop = _loop_config().get_retry_loop(TextProblemStatement(text="fix the bug"))
+    loop.on_submit(_submission(2.0))
+    loop.on_submit(_submission(3.0))
+
+    # Stand in for a chooser query that has already happened.
+    loop._chooser.model.stats = InstanceStats(instance_cost=6.75, api_calls=1)
+
+    assert loop.review_model_stats.instance_cost == pytest.approx(6.75)
+    assert loop._total_stats.instance_cost == pytest.approx(11.75)
+
+
+def test_preselector_cost_is_reported():
+    loop = _loop_config(with_preselector=True).get_retry_loop(TextProblemStatement(text="fix the bug"))
+    loop.on_submit(_submission(1.0))
+
+    chooser = loop._chooser
+    chooser.model.stats = InstanceStats(instance_cost=2.0, api_calls=1)
+    # `choose()` builds the preselector lazily; once built its spend must count.
+    chooser._preselector = chooser.config.preselector and _PreselectorStub(0.5)
+
+    assert loop.review_model_stats.instance_cost == pytest.approx(2.5)
+    assert loop._total_stats.instance_cost == pytest.approx(3.5)
+
+
+def test_retry_budget_is_driven_by_attempt_cost():
+    """`cost_limit` is documented as excluding the choosing step.
+
+    The chooser has not run while `retry()` is being asked, so reporting its
+    spend through `_total_stats` leaves the budget decisions untouched.
+    """
+    loop = _loop_config().get_retry_loop(TextProblemStatement(text="fix the bug"))
+    loop.on_submit(_submission(2.0))
+    assert loop.retry() is True
+
+    loop.on_submit(_submission(3.5))  # $5.5 of $6 spent, under the $1 floor
+    assert loop.retry() is False
+
+
+class _PreselectorStub:
+    """Minimal stand-in exposing the one attribute `Chooser.stats` reads."""
+
+    def __init__(self, cost: float):
+        self.model = type("M", (), {"stats": InstanceStats(instance_cost=cost, api_calls=1)})()


### PR DESCRIPTION
Fixes #1485.

## The bug

`ChooserRetryLoop.review_model_stats` returns a fresh empty `InstanceStats()`, and `_total_stats` sums only the per-submission `model_stats`. The chooser model's own spend is folded in nowhere, so a trajectory reports `$0` of review cost regardless of what the chooser actually cost. The sibling `ScoreRetryLoop` does report its reviewer model in both places, so the two loops account for their "pick the best" model inconsistently.

That matters with the shipped `config/benchmarks/250212_sweagent_heavy_sbl.yaml`: `chooser.model: o1` at `reasoning_effort: high` against a `$6` loop budget — one query there can cost more than the entire loop.

## The change

- `Chooser.stats` exposes the chooser model's stats plus the preselector's.
- `ChooserRetryLoop.review_model_stats` returns it; `_total_stats` adds it.
- The preselector is built once and kept on the `Chooser` rather than constructed and dropped inside `choose()` — otherwise its spend has nowhere to be read from afterwards. It is still built lazily, so a configured-but-unused preselector costs nothing.

Budget behaviour is deliberately unchanged. The chooser only runs in `get_best()`, after the retry loop has terminated, so its cost is still zero at every point `retry()` inspects `_total_stats` — which is exactly what the `cost_limit` docstring promises ("Does not include cost of choosing"). This PR fixes the reporting gap the issue describes, not the budget exclusion, which reads deliberate.

## Evidence

`tests/test_chooser_retry_loop.py`, 3 tests. Against the unpatched `reviewer.py`:

```
FAILED tests/test_chooser_retry_loop.py::test_chooser_cost_is_reported
FAILED tests/test_chooser_retry_loop.py::test_preselector_cost_is_reported
2 failed, 1 passed
```

With the fix: `3 passed`. The third test is the one that passes either way — it pins the `cost_limit` behaviour so a later change cannot quietly start charging attempts for the chooser. `ruff check` / `ruff format --check` clean.

Note for review order: this touches `Chooser.choose` two lines above #1504's edit. Whichever lands first, I'll rebase the other.