### PR TITLE
feat(models): record provider cache read/write tokens

### DIFF
--- a/sweagent/agent/models.py
+++ b/sweagent/agent/models.py
@@ -270,6 +270,33 @@ ModelConfig = Annotated[
 ]
 
 
+def extract_cache_usage(response: Any) -> tuple[int, int]:
+    """Cache read/write input-token counts reported by the provider.
+
+    Providers name these differently: Anthropic reports
+    `cache_read_input_tokens`/`cache_creation_input_tokens` on the usage object,
+    while OpenAI-style responses report only reads, under
+    `prompt_tokens_details.cached_tokens`. Anything else reports neither, in
+    which case both counts are 0.
+
+    Returns:
+        `(cache_read_tokens, cache_write_tokens)`
+    """
+    usage = getattr(response, "usage", None)
+    if usage is None:
+        return 0, 0
+
+    def _int(value: Any) -> int:
+        return int(value) if isinstance(value, (int, float)) else 0
+
+    read = _int(getattr(usage, "cache_read_input_tokens", None))
+    if not read:
+        details = getattr(usage, "prompt_tokens_details", None)
+        read = _int(getattr(details, "cached_tokens", None)) if details is not None else 0
+    write = _int(getattr(usage, "cache_creation_input_tokens", None))
+    return read, write
+
+
 class GlobalStats(PydanticBaseModel):
     """This class tracks usage numbers (costs etc.) across all instances."""
 
@@ -296,6 +323,10 @@ class InstanceStats(PydanticBaseModel):
     tokens_sent: int = 0
     tokens_received: int = 0
     api_calls: int = 0
+    cache_read_tokens: int = 0
+    """Input tokens the provider served from its prompt cache. A subset of `tokens_sent`."""
+    cache_write_tokens: int = 0
+    """Input tokens the provider charged for writing a new cache entry. A subset of `tokens_sent`."""
 
     def __add__(self, other: InstanceStats) -> InstanceStats:
         return InstanceStats(
@@ -629,18 +660,30 @@ class LiteLLMModel(AbstractModel):
         """Cost limit for the model. Returns 0 if there is no limit."""
         return self.config.per_instance_cost_limit
 
-    def _update_stats(self, *, input_tokens: int, output_tokens: int, cost: float) -> None:
+    def _update_stats(
+        self,
+        *,
+        input_tokens: int,
+        output_tokens: int,
+        cost: float,
+        cache_read_tokens: int = 0,
+        cache_write_tokens: int = 0,
+    ) -> None:
         with GLOBAL_STATS_LOCK:
             GLOBAL_STATS.total_cost += cost
         self.stats.instance_cost += cost
         self.stats.tokens_sent += input_tokens
         self.stats.tokens_received += output_tokens
+        self.stats.cache_read_tokens += cache_read_tokens
+        self.stats.cache_write_tokens += cache_write_tokens
         self.stats.api_calls += 1
 
         # Log updated cost values to std. err
         self.logger.debug(
             f"input_tokens={input_tokens:,}, "
             f"output_tokens={output_tokens:,}, "
+            f"cache_read_tokens={cache_read_tokens:,}, "
+            f"cache_write_tokens={cache_write_tokens:,}, "
             f"instance_cost={self.stats.instance_cost:.2f}, "
             f"cost={cost:.2f}",
         )
@@ -777,7 +820,14 @@ class LiteLLMModel(AbstractModel):
             ):
                 output_dict["thinking_blocks"] = response.choices[i].message.thinking_blocks  # type: ignore
             outputs.append(output_dict)
-        self._update_stats(input_tokens=input_tokens, output_tokens=output_tokens, cost=cost)
+        cache_read_tokens, cache_write_tokens = extract_cache_usage(response)
+        self._update_stats(
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            cost=cost,
+            cache_read_tokens=cache_read_tokens,
+            cache_write_tokens=cache_write_tokens,
+        )
         return outputs
 
     def _query(

--- a/sweagent/inspector/server.py
+++ b/sweagent/inspector/server.py
@@ -90,12 +90,18 @@ def append_results(traj_path: Path, instance_id: str, content, results, results_
     tokens_received = f"{tokens_received:,}" if tokens_received is not None else "N/A"
     api_calls = model_stats.get("api_calls", None)
     api_calls = f"{api_calls:,}" if api_calls is not None else "N/A"
+    cache_read_tokens = model_stats.get("cache_read_tokens", None)
+    cache_read_tokens = f"{cache_read_tokens:,}" if cache_read_tokens is not None else "N/A"
+    cache_write_tokens = model_stats.get("cache_write_tokens", None)
+    cache_write_tokens = f"{cache_write_tokens:,}" if cache_write_tokens is not None else "N/A"
 
     stats.append("**** Run Stats ****")
     stats.append(f"Exit Status: {exit_status}")
     stats.append(f"Instance Cost: ${instance_cost}")
     stats.append(f"Tokens Sent: {tokens_sent}")
     stats.append(f"Tokens Received: {tokens_received}")
+    stats.append(f"Cache Read Tokens: {cache_read_tokens}")
+    stats.append(f"Cache Write Tokens: {cache_write_tokens}")
     stats.append(f"API Calls: {api_calls}\n")
 
     # Build status section

--- a/tests/test_cache_token_stats.py
+++ b/tests/test_cache_token_stats.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from sweagent.agent.models import (
+    GenericAPIModelConfig,
+    InstanceStats,
+    LiteLLMModel,
+    extract_cache_usage,
+)
+from sweagent.tools.parsing import ActionParser
+from sweagent.tools.tools import ToolConfig
+
+
+def _anthropic_usage(read: int, write: int):
+    return SimpleNamespace(
+        prompt_tokens=100,
+        completion_tokens=10,
+        total_tokens=110,
+        cache_read_input_tokens=read,
+        cache_creation_input_tokens=write,
+    )
+
+
+def _openai_usage(cached: int):
+    return SimpleNamespace(
+        prompt_tokens=100,
+        completion_tokens=10,
+        total_tokens=110,
+        prompt_tokens_details=SimpleNamespace(cached_tokens=cached),
+    )
+
+
+@pytest.mark.parametrize(
+    ("usage", "expected"),
+    [
+        (_anthropic_usage(1200, 800), (1200, 800)),
+        (_anthropic_usage(0, 0), (0, 0)),
+        (_openai_usage(1536), (1536, 0)),
+        (_openai_usage(0), (0, 0)),
+        (SimpleNamespace(prompt_tokens=10, completion_tokens=1), (0, 0)),
+        (None, (0, 0)),
+    ],
+)
+def test_extract_cache_usage(usage, expected):
+    assert extract_cache_usage(SimpleNamespace(usage=usage)) == expected
+
+
+def test_extract_cache_usage_without_usage_attribute():
+    assert extract_cache_usage(object()) == (0, 0)
+
+
+def test_cache_tokens_reach_the_stats():
+    model = LiteLLMModel(
+        GenericAPIModelConfig(name="gpt-4o", api_key="dummy", per_instance_cost_limit=0, total_cost_limit=0),
+        ToolConfig(parse_function=ActionParser()),
+    )
+    model._history_to_messages = lambda history: [{"role": "user", "content": "test"}]
+
+    message = SimpleNamespace(content="action: no_action", tool_calls=None, thinking_blocks=None)
+    response = SimpleNamespace(
+        choices=[SimpleNamespace(message=message, finish_reason="stop")],
+        usage=_anthropic_usage(1200, 800),
+        model="gpt-4o",
+    )
+
+    with patch("litellm.completion", return_value=response):
+        model.query(None)
+        model.query(None)
+
+    assert model.stats.cache_read_tokens == 2400
+    assert model.stats.cache_write_tokens == 1600
+
+
+def test_cache_tokens_add_across_instance_stats():
+    total = InstanceStats(cache_read_tokens=10, cache_write_tokens=3) + InstanceStats(
+        cache_read_tokens=5, cache_write_tokens=1
+    )
+    assert (total.cache_read_tokens, total.cache_write_tokens) == (15, 4)
+
+
+def test_old_trajectories_still_parse():
+    """The new fields default to 0, so stats written before this change still load."""
+    stats = InstanceStats.model_validate({"instance_cost": 1.0, "tokens_sent": 5, "tokens_received": 2, "api_calls": 1})
+    assert (stats.cache_read_tokens, stats.cache_write_tokens) == (0, 0)


### PR DESCRIPTION
Fixes #1481.

## The gap

`models.py` never reads `response.usage` — grepping for `response.usage`, `cache_read_input`, `cache_creation_input` or `prompt_tokens_details` returns nothing. Input tokens are counted client-side with `litellm.utils.token_counter` and that estimate is the only thing that reaches the stats, so a cache read, a cache write and uncached input are indistinguishable in `tokens_sent` even though they bill at roughly 0.1x, 1.25x and 1x. Nothing in SWE-agent's own telemetry says whether the prefix caching in `history_processors.py` is working well, badly, or at all.

As the issue is careful to note, `cost` comes from litellm's calculator, which *does* read usage — so the dollar figure was already right. It's the token statistics that were blind.

## The change

- `extract_cache_usage(response)` reads the counts providers actually report: `cache_read_input_tokens` / `cache_creation_input_tokens` (Anthropic through litellm) and `prompt_tokens_details.cached_tokens` (OpenAI-style, reads only). Anything else yields `(0, 0)`.
- `InstanceStats` gains `cache_read_tokens` and `cache_write_tokens`, accumulated in `_update_stats` and included in the debug log line.
- The trajectory inspector's run-stats panel shows both.

Deliberately *not* changed: `tokens_sent` keeps its existing client-side meaning, so no historical number moves. The new fields are subsets of it and both default to `0`, so trajectories written before this still validate — there's a test for that.

## Evidence

`tests/test_cache_token_stats.py`, 10 tests, all passing: both provider usage shapes, a response reporting neither, a response with no `usage` at all, accumulation across two queries through the real `query()` path, `InstanceStats.__add__`, and an old-shape stats payload still loading. `tests/test_models.py` and `tests/test_quick_stats.py` still pass (6 passed). `ruff check` / `ruff format --check` clean.

What I could not check locally: I have no Anthropic or OpenAI key here, so the usage shapes are taken from the provider docs and litellm's types rather than from a live response. If either field name has drifted, `extract_cache_usage` degrades to reporting 0 rather than breaking anything — but it's the part worth a second pair of eyes.

The companion issue #1482 (1-hour cache TTL) is untouched; this is the prerequisite the reporter describes, not that fix.