### PR TITLE
feat(history): make the cache breakpoint TTL configurable

### DIFF
--- a/sweagent/agent/history_processors.py
+++ b/sweagent/agent/history_processors.py
@@ -50,21 +50,30 @@ def _clear_cache_control(entry: HistoryItem) -> None:
     entry.pop("cache_control", None)
 
 
-def _set_cache_control(entry: HistoryItem) -> None:
+def _set_cache_control(entry: HistoryItem, ttl: str | None = None) -> None:
+    """Mark `entry` as a cache breakpoint.
+
+    Args:
+        ttl: Cache lifetime to request, e.g. `"1h"`. `None` leaves it to the
+            provider's default, which for Anthropic is five minutes.
+    """
+    cache_control: dict[str, str] = {"type": "ephemeral"}
+    if ttl is not None:
+        cache_control["ttl"] = ttl
     if not isinstance(entry["content"], list):
         entry["content"] = [  # type: ignore
             {
                 "type": "text",
                 "text": _get_content_text(entry),
-                "cache_control": {"type": "ephemeral"},
+                "cache_control": dict(cache_control),
             }
         ]
     else:
-        entry["content"][0]["cache_control"] = {"type": "ephemeral"}
+        entry["content"][0]["cache_control"] = dict(cache_control)
     if entry["role"] == "tool":
         # Workaround for weird bug
         entry["content"][0].pop("cache_control", None)
-        entry["cache_control"] = {"type": "ephemeral"}
+        entry["cache_control"] = dict(cache_control)
 
 
 # History processors
@@ -282,6 +291,14 @@ class CacheControlHistoryProcessor(BaseModel):
     tagged_roles: list[str] = ["user", "tool"]
     """Only add cache control to messages with these roles."""
 
+    ttl: str | None = None
+    """Cache lifetime to request at each breakpoint, e.g. `"1h"`.
+    `None` (the default) sends no `ttl` and therefore gets the provider's default,
+    which is five minutes for Anthropic. A longer TTL costs more to write and less
+    to read, so it pays off when the gap between two model calls regularly exceeds
+    the default lifetime and loses when it does not.
+    """
+
     # pydantic config
     model_config = ConfigDict(extra="forbid")
 
@@ -296,7 +313,7 @@ class CacheControlHistoryProcessor(BaseModel):
                 and entry["role"] in self.tagged_roles
                 and i_entry >= self.last_n_messages_offset
             ):
-                _set_cache_control(entry)
+                _set_cache_control(entry, ttl=self.ttl)
                 n_tagged += 1
             new_history.append(entry)
         return list(reversed(new_history))

--- a/tests/test_cache_control_ttl.py
+++ b/tests/test_cache_control_ttl.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import pytest
+
+from sweagent.agent.history_processors import CacheControlHistoryProcessor
+
+
+def _history() -> list[dict]:
+    return [
+        {"role": "system", "content": "system", "message_type": "system_prompt", "agent": "main"},
+        {"role": "user", "content": "first", "message_type": "observation", "agent": "main"},
+        {"role": "assistant", "content": "thought", "message_type": "action", "agent": "main"},
+        {"role": "user", "content": "second", "message_type": "observation", "agent": "main"},
+    ]
+
+
+def _cache_controls(history: list[dict]) -> list[dict]:
+    marks = []
+    for entry in history:
+        if isinstance(entry.get("content"), list):
+            marks += [item["cache_control"] for item in entry["content"] if "cache_control" in item]
+        if "cache_control" in entry:
+            marks.append(entry["cache_control"])
+    return marks
+
+
+def test_default_sends_no_ttl():
+    """Unchanged behaviour: no `ttl` key, so the provider default applies."""
+    processed = CacheControlHistoryProcessor()(_history())  # type: ignore[arg-type]
+    marks = _cache_controls(processed)
+    assert marks
+    assert all(mark == {"type": "ephemeral"} for mark in marks)
+
+
+@pytest.mark.parametrize("ttl", ["1h", "5m"])
+def test_ttl_is_forwarded(ttl):
+    processed = CacheControlHistoryProcessor(ttl=ttl)(_history())  # type: ignore[arg-type]
+    marks = _cache_controls(processed)
+    assert marks
+    assert all(mark == {"type": "ephemeral", "ttl": ttl} for mark in marks)
+
+
+def test_marks_are_not_shared_between_entries():
+    """Each breakpoint gets its own dict, so mutating one cannot alter another."""
+    processed = CacheControlHistoryProcessor(last_n_messages=2, ttl="1h")(_history())  # type: ignore[arg-type]
+    marks = _cache_controls(processed)
+    assert len(marks) >= 2
+    marks[0]["ttl"] = "mutated"
+    assert marks[1]["ttl"] == "1h"
+
+
+def test_tool_entries_carry_the_ttl():
+    history = [{"role": "tool", "content": "output", "message_type": "observation", "agent": "main"}]
+    processed = CacheControlHistoryProcessor(ttl="1h")(history)  # type: ignore[arg-type]
+    assert processed[0]["cache_control"] == {"type": "ephemeral", "ttl": "1h"}
+    assert all("cache_control" not in item for item in processed[0]["content"])


### PR DESCRIPTION
Fixes #1482.

## The gap

`_set_cache_control` emits `{"type": "ephemeral"}` at all three call sites and nothing anywhere sets a `ttl`. That is the five-minute cache; the one-hour cache needs `{"type": "ephemeral", "ttl": "1h"}`. So a run whose model calls are spaced more than five minutes apart — a large `config.delay`, or just long-running actions between calls — rewrites the cached prefix on every request instead of reading it, and there is no configuration that changes that.

As the issue is careful to say, 1h is not universally better: it costs more to write, so it wins only when the gap between calls lands between five minutes and an hour, and loses outside that band. That is why this is a knob rather than a new default.

## The change

`CacheControlHistoryProcessor.ttl`, threaded into `_set_cache_control`. The default is `None`, which sends no `ttl` key at all — byte-identical requests to today. The rolling-breakpoint placement (`_clear_cache_control` then `_set_cache_control`) is untouched; the issue explicitly flags that as deliberate.

Each breakpoint now gets its own dict rather than sharing one literal, so a mutation of one mark cannot leak into another.

## Evidence

`tests/test_cache_control_ttl.py`, 5 tests: the default still emits a bare `{"type": "ephemeral"}`, a configured TTL reaches every breakpoint including the `role == "tool"` workaround path, and the marks are independent objects. Four of the five fail against the unpatched `history_processors.py` (`git stash` of just that file); the one that passes is the default-behaviour test, which is the point — it pins that this opt-in did not become a behaviour change. `ruff check` / `ruff format --check` clean. Existing `tests/test_history_processors.py` still passes.

What I did not do: measure it. The reporter's numbers (40.2% cheaper on a 16k-token static prefix across a 15-minute schedule, on `claude-sonnet-4-6`) are theirs, not mine — I have no Anthropic key here, and as they note, whether real SWE-agent trajectories fall in the band where 1h wins depends on step duration, which neither of us has measured on real runs. With #1508 (cache read/write token accounting) that becomes measurable from a normal run's own stats, which is the order they suggested doing these in.