### PR TITLE
fix: handle compare-runs with no shared instances

### DIFF
--- a/sweagent/run/compare_runs.py
+++ b/sweagent/run/compare_runs.py
@@ -52,7 +52,7 @@ def compare_many(paths: list[Path]) -> None:
         n_success = sum(id in resolved_ids[path] for id in ids_to_compare)
         n_evaluated = sum(id in evaluated_ids[path] for id in ids_to_compare)
         successes.append(n_success)
-        success_rates.append(f"{n_success / n_evaluated:.2f}")
+        success_rates.append(f"{n_success / n_evaluated:.2f}" if n_evaluated else "N/A")
     table.append(successes)
     table.append(success_rates)
     print(tabulate(table, headers=header))

--- a/tests/test_compare_runs.py
+++ b/tests/test_compare_runs.py
@@ -6,9 +6,7 @@ import pytest
 from sweagent.run.compare_runs import run_from_cli
 
 
-def test_compare_many_handles_run_without_common_instances(
-    tmp_path: Path, capsys: pytest.CaptureFixture[str]
-) -> None:
+def test_compare_many_handles_run_without_common_instances(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
     results = [
         {"submitted_ids": ["case-a"], "resolved_ids": ["case-a"]},
         {"submitted_ids": ["case-b"], "resolved_ids": ["case-b"]},

--- a/tests/test_compare_runs.py
+++ b/tests/test_compare_runs.py
@@ -1,0 +1,31 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from sweagent.run.compare_runs import run_from_cli
+
+
+def test_compare_many_handles_run_without_common_instances(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    results = [
+        {"submitted_ids": ["case-a"], "resolved_ids": ["case-a"]},
+        {"submitted_ids": ["case-b"], "resolved_ids": ["case-b"]},
+        {"submitted_ids": ["case-a"], "resolved_ids": []},
+    ]
+    paths = []
+    for index, result in enumerate(results):
+        run_dir = tmp_path / f"run-{index}"
+        run_dir.mkdir()
+        (run_dir / "results.json").write_text(json.dumps(result))
+        paths.append(str(run_dir))
+
+    run_from_cli(paths)
+
+    rows = [line.split() for line in capsys.readouterr().out.splitlines() if "run-" in line]
+    assert rows == [
+        ["0", "run-0", "1", "1.00"],
+        ["1", "run-1", "0", "N/A"],
+        ["2", "run-2", "0", "0.00"],
+    ]


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!
-->

#### Reference Issues/PRs

No existing issue. Exact issue/PR searches found no equivalent report or fix.

#### What does this implement/fix? Explain your changes.

When `compare-runs` receives three or more result sets, a run may have no evaluated IDs in common with the first run's comparison cohort. The per-run summary currently divides by that valid zero count and exits with `ZeroDivisionError`.

This change renders the undefined rate as `N/A`, preserving the existing two-decimal rate for evaluated runs. The regression exercises the public CLI path and verifies that successful (`1.00`), unevaluated (`N/A`), and evaluated-failure (`0.00`) summaries remain distinct.

## Regression evidence

- Before: `.venv/bin/pytest tests/test_compare_runs.py::test_compare_many_handles_run_without_common_instances -q` exited `1` with `ZeroDivisionError`.
- After: the same command exited `0`.

## Verification

- `.venv/bin/pytest tests/test_compare_runs.py -q` — 1 passed.
- `PATH="$PWD/.venv/bin:$PATH" .venv/bin/pytest --ignore=tests/test_env.py --deselect=tests/test_run_replay.py::test_replay -m 'not slow' -n auto -q` — 109 passed, 2 xfailed.
- `.venv/bin/pre-commit run --all-files` — all hooks passed.
- `.venv/bin/mkdocs build` — passed.

The full CI-shaped suite was also attempted locally, but Docker-dependent tests could not complete because `docker-credential-desktop` stalled while pulling `python:3.11`; those tests are left to GitHub CI.

## Scope

- 2 files changed, +30 / -1 lines.
