### PR TITLE
fix(tools): don't re-slice multiline matches relative to rem_action

### DIFF
--- a/sweagent/tools/utils.py
+++ b/sweagent/tools/utils.py
@@ -24,7 +24,7 @@ def _guard_multiline_input(action: str, match_fct: Callable[[str], re.Match | No
             if match_action.strip():
                 eof = first_match.group(3).strip()
                 if not match_action.split("\n")[0].strip().endswith(f"<< '{eof}'"):
-                    guarded_command = match_action[first_match.start() :]
+                    guarded_command = match_action
                     first_line = guarded_command.split("\n")[0]
                     guarded_command = guarded_command.replace(first_line, first_line + f" << '{eof}'", 1)
                     parsed_action.append(guarded_command)


### PR DESCRIPTION
## Summary
- `_guard_multiline_input` sliced `match_action[first_match.start():]` after already matching against `rem_action`, so offsets were wrong whenever the match wasn't at the start of `rem_action`.
- Use `match_action` (the matched substring) directly when building the rewritten action.

## Test plan
- [ ] Unit / manual: multiline guard with a match that doesn't start at offset 0 of `rem_action`
- [ ] Existing tools/parser tests still pass