### PR TITLE
fix(tools): use Argument.name in multiline get_signature

### DIFF
--- a/sweagent/tools/utils.py
+++ b/sweagent/tools/utils.py
@@ -68,7 +68,7 @@ def get_signature(cmd):
                     signature += f" <{param}>"
                 else:
                     signature += f" [<{param}>]"
-            signature += f"\n{list(cmd.arguments[-1].keys())[0]}\n{cmd.end_name}"
+            signature += f"\n{cmd.arguments[-1].name}\n{cmd.end_name}"
     return signature
 
 


### PR DESCRIPTION
## Summary
- `get_signature` used `cmd.arguments[-1].keys()` but `Argument` objects expose `.name`, so building the multiline signature raised `AttributeError`.
- Read `.name` from the last argument instead.

## Test plan
- [ ] Call get_signature on a multiline-capable command
- [ ] Existing tool signature tests pass
