### PR TITLE
fix(run): don't reference loop variable when merging empty preds

### DIFF
--- a/sweagent/run/merge_predictions.py
+++ b/sweagent/run/merge_predictions.py
@@ -25,7 +25,7 @@ def merge_predictions(directories: list[Path], output: Path | None = None) -> No
         logger.debug("Found %d predictions in %s", len(new), directory)
     logger.info("Found %d predictions", len(preds))
     if not preds:
-        logger.warning("No predictions found in %s", directory)
+        logger.warning("No predictions found in %s", directories)
         return
     if output is None:
         output = directories[0] / "preds.json"


### PR DESCRIPTION
## Summary
- Empty-directory warning used unbound `directory` from a prior loop scope.
- Log with the actual `directories` list being skipped.

## Test plan
- [ ] Merge predictions with an empty input directory
- [ ] Existing merge_predictions tests pass
