### PR TITLE
fix(tools): raise ValueError when bash is disabled with a bad parser

### DIFF
--- a/sweagent/tools/tools.py
+++ b/sweagent/tools/tools.py
@@ -207,7 +207,7 @@ class ToolConfig(BaseModel):
         if not self.enable_bash_tool and not (
             isinstance(self.parse_function, FunctionCallingParser) or isinstance(self.parse_function, JsonParser)
         ):
-            msg = f"Bash tool can only be disabled if {FunctionCallingParser.type} parser or {JsonParser.type} parser is used."
+            msg = "Bash tool can only be disabled if function_calling parser or json parser is used."
             raise ValueError(msg)
 
         self.multi_line_command_endings = multi_line_command_endings


### PR DESCRIPTION
## Summary
- Error path referenced `Parser.type` as if it were an enum member; with bash disabled this raised `AttributeError` instead of the intended configuration error.
- Raise `ValueError` with a clear message using string literals.

## Test plan
- [ ] Configure a non-bash parser while bash is disabled and confirm ValueError
- [ ] Default bash parser path unchanged
