### PR TITLE
fix(tools): allow r2 -c through block_unless_regex

### DIFF
--- a/sweagent/tools/tools.py
+++ b/sweagent/tools/tools.py
@@ -67,7 +67,7 @@ class ToolFilterConfig(BaseModel):
 
     block_unless_regex: dict[str, str] = {
         "radare2": r"\b(?:radare2)\b.*\s+-c\s+.*",
-        "r2": r"\b(?:radare2)\b.*\s+-c\s+.*",
+        "r2": r"\b(?:r2)\b.*\s+-c\s+.*",
     }
     """Block any command that matches one of these names unless it also matches the regex"""
 


### PR DESCRIPTION
## Summary
- `block_unless_regex["r2"]` reused the `radare2` pattern, so `r2 -c '…'` never matched and was always blocked.
- Point the `r2` entry at `\b(?:r2)\b…-c…` so the short binary is allowed the same way as `radare2 -c`.

## Test plan
- [ ] `should_block_action("r2 -c 'aaa'")` is false; bare `r2` remains blocked
- [ ] `radare2 -c '…'` still allowed via its own pattern
