### PR TITLE
fix(models): default message for raise_function_calling without text

### DIFF
--- a/sweagent/agent/models.py
+++ b/sweagent/agent/models.py
@@ -335,10 +335,9 @@ def _handle_raise_commands(action: str) -> None:
     elif action.startswith("raise_function_calling"):
         parts = shlex.split(action)
         error_code = parts[1]
-        if len(parts) == 3:
-            error_message = parts[2]
+        error_message = parts[2] if len(parts) == 3 else ""
         assert len(parts) < 4
-        raise FunctionCallingFormatError(error_message, error_code)  # type: ignore
+        raise FunctionCallingFormatError(error_message, error_code)
 
 
 class HumanModel(AbstractModel):


### PR DESCRIPTION
## Summary
- `raise_function_calling <code>` without a message left `error_message` unset and raised `UnboundLocalError` instead of `FunctionCallingFormatError`.
- Default the message to `""` so human/test harnesses can inject format errors by code alone.

## Test plan
- [ ] `_handle_raise_commands("raise_function_calling missing")` raises `FunctionCallingFormatError`
- [ ] Three-token form still passes the custom message through
