### PR TITLE
fix(history): tag observations for TagToolCallObservations keep_output

### DIFF
--- a/sweagent/agent/history_processors.py
+++ b/sweagent/agent/history_processors.py
@@ -206,9 +206,18 @@ class TagToolCallObservations(BaseModel):
         return bool(self.function_names & function_names)
 
     def __call__(self, history: History) -> History:
+        # LastNObservations only honors keep_output on observation entries.
+        # Tag the observation that follows a matching action (and the action itself).
+        tag_next_observation = False
         for entry in history:
-            if self._should_add_tags(entry):
+            if entry.get("message_type") == "action" and self._should_add_tags(entry):
                 self._add_tags(entry)
+                tag_next_observation = True
+            elif entry.get("message_type") == "observation" and tag_next_observation:
+                self._add_tags(entry)
+                tag_next_observation = False
+            else:
+                tag_next_observation = False
         return history
 
 


### PR DESCRIPTION
## Summary
- `TagToolCallObservations` only tagged matching **actions**, but `LastNObservations` only preserves content when **observations** carry `keep_output`.
- Tag the following observation (and the action) so configured tool outputs are actually retained.

## Test plan
- [ ] History with many `str_replace_editor` action/observation pairs keeps tagged observation bodies after `LastNObservations`
