### PR TITLE
fix(history): preserve numbered output without file headers

### DIFF
--- a/sweagent/agent/history_processors.py
+++ b/sweagent/agent/history_processors.py
@@ -244,6 +244,7 @@ class ClosedWindowHistoryProcessor(BaseModel):
                 if file_match:
                     file = file_match.group(1)
                 else:
+                    new_history.append(data)
                     continue
                 if file in windows:
                     start = matches[0].start()

--- a/tests/test_closed_window_history.py
+++ b/tests/test_closed_window_history.py
@@ -1,0 +1,25 @@
+import pytest
+
+from sweagent.agent.history_processors import ClosedWindowHistoryProcessor
+
+
+@pytest.mark.parametrize("content", ["1: first result\n2: second result\n", "Build failed\n42: error: missing name\n"])
+def test_closed_window_preserves_numbered_output_without_file_header(content):
+    history = [{"role": "user", "content": content, "message_type": "observation"}]
+    assert ClosedWindowHistoryProcessor()(history) == history
+
+
+def test_closed_window_only_elides_older_windows_for_the_same_file():
+    def observation(content):
+        return {"role": "user", "content": content, "message_type": "observation"}
+
+    history = [
+        observation("[File: example.py (2 lines total)]\n1: old\n2: text\n"),
+        observation("1: unrelated command output\n"),
+        observation("[File: example.py (2 lines total)]\n1: new\n2: text\n"),
+    ]
+    result = ClosedWindowHistoryProcessor()(history)
+    assert len(result) == len(history)
+    assert "Outdated window with 2 lines omitted" in result[0]["content"]
+    assert result[1:] == history[1:]
+    assert "1: old" in history[0]["content"]

--- a/tests/test_history_processors.py
+++ b/tests/test_history_processors.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import pytest
 
-from sweagent.agent.history_processors import ClosedWindowHistoryProcessor, LastNObservations, TagToolCallObservations
+from sweagent.agent.history_processors import LastNObservations, TagToolCallObservations
 from sweagent.types import History
 
 
@@ -38,25 +38,3 @@ def test_add_tag_to_edits(test_history: History):
     for entry in new_history:
         if entry.get("action", "").startswith("edit "):  # type: ignore
             assert entry.get("tags") == ["test"], entry
-
-
-@pytest.mark.parametrize("content", ["1: first result\n2: second result\n", "Build failed\n42: error: missing name\n"])
-def test_closed_window_preserves_numbered_output_without_file_header(content):
-    history = [{"role": "user", "content": content, "message_type": "observation"}]
-    assert ClosedWindowHistoryProcessor()(history) == history
-
-
-def test_closed_window_only_elides_older_windows_for_the_same_file():
-    def observation(content):
-        return {"role": "user", "content": content, "message_type": "observation"}
-
-    history = [
-        observation("[File: example.py (2 lines total)]\n1: old\n2: text\n"),
-        observation("1: unrelated command output\n"),
-        observation("[File: example.py (2 lines total)]\n1: new\n2: text\n"),
-    ]
-    result = ClosedWindowHistoryProcessor()(history)
-    assert len(result) == len(history)
-    assert "Outdated window with 2 lines omitted" in result[0]["content"]
-    assert result[1:] == history[1:]
-    assert "1: old" in history[0]["content"]

--- a/tests/test_history_processors.py
+++ b/tests/test_history_processors.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import pytest
 
-from sweagent.agent.history_processors import LastNObservations, TagToolCallObservations
+from sweagent.agent.history_processors import ClosedWindowHistoryProcessor, LastNObservations, TagToolCallObservations
 from sweagent.types import History
 
 
@@ -38,3 +38,25 @@ def test_add_tag_to_edits(test_history: History):
     for entry in new_history:
         if entry.get("action", "").startswith("edit "):  # type: ignore
             assert entry.get("tags") == ["test"], entry
+
+
+@pytest.mark.parametrize("content", ["1: first result\n2: second result\n", "Build failed\n42: error: missing name\n"])
+def test_closed_window_preserves_numbered_output_without_file_header(content):
+    history = [{"role": "user", "content": content, "message_type": "observation"}]
+    assert ClosedWindowHistoryProcessor()(history) == history
+
+
+def test_closed_window_only_elides_older_windows_for_the_same_file():
+    def observation(content):
+        return {"role": "user", "content": content, "message_type": "observation"}
+
+    history = [
+        observation("[File: example.py (2 lines total)]\n1: old\n2: text\n"),
+        observation("1: unrelated command output\n"),
+        observation("[File: example.py (2 lines total)]\n1: new\n2: text\n"),
+    ]
+    result = ClosedWindowHistoryProcessor()(history)
+    assert len(result) == len(history)
+    assert "Outdated window with 2 lines omitted" in result[0]["content"]
+    assert result[1:] == history[1:]
+    assert "1: old" in history[0]["content"]


### PR DESCRIPTION
Closed-window history processing silently discarded an entire user observation when its output contained numbered lines but lacked a `[File: ...]` header. This can hide ordinary command output or diagnostics from the agent. Preserve those observations while continuing to elide only older windows for the same file.

Validation: all 5 history-processor tests pass, including three regressions that fail on current main (two plain numbered outputs and a sequence mixing old/new file windows with unrelated output). Ruff check/format and `git diff --check` pass. The regression also confirms the original history remains unchanged.
