### PR TITLE
fix(history): parse images in existing multimodal messages

### DIFF
--- a/sweagent/agent/history_processors.py
+++ b/sweagent/agent/history_processors.py
@@ -353,9 +353,22 @@ class ImageParsingHistoryProcessor(BaseModel):
         if entry.get("role") not in ["user", "tool"]:
             return entry
         entry = copy.deepcopy(entry)
-        content = _get_content_text(entry)
-        segments = self._parse_images(content)
-        if any(seg["type"] == "image_url" for seg in segments):
+        content = entry["content"]
+        if isinstance(content, str):
+            segments = self._parse_images(content)
+            if any(seg["type"] == "image_url" for seg in segments):
+                entry["content"] = segments
+        else:
+            segments = []
+            for item in content:
+                if item.get("type") != "text":
+                    segments.append(item)
+                    continue
+                parsed = self._parse_images(item["text"])
+                if any(seg["type"] == "image_url" for seg in parsed):
+                    segments.extend(parsed)
+                else:
+                    segments.append(item)
             entry["content"] = segments
         return entry
 

--- a/tests/test_history_processors.py
+++ b/tests/test_history_processors.py
@@ -1,9 +1,10 @@
+import copy
 import json
 from pathlib import Path
 
 import pytest
 
-from sweagent.agent.history_processors import LastNObservations, TagToolCallObservations
+from sweagent.agent.history_processors import ImageParsingHistoryProcessor, LastNObservations, TagToolCallObservations
 from sweagent.types import History
 
 
@@ -38,3 +39,33 @@ def test_add_tag_to_edits(test_history: History):
     for entry in new_history:
         if entry.get("action", "").startswith("edit "):  # type: ignore
             assert entry.get("tags") == ["test"], entry
+
+
+@pytest.mark.parametrize("role", ["user", "tool"])
+def test_image_parsing_preserves_existing_multimodal_content(role):
+    image = {"type": "image_url", "image_url": {"url": "data:image/png;base64,b2xk"}}
+    history = [
+        {
+            "role": role,
+            "content": [
+                {"type": "text", "text": "existing image"},
+                image,
+                {"type": "text", "text": "new image ![new](data:image/png;base64,bmV3)"},
+            ],
+            "message_type": "observation",
+        }
+    ]
+    original = copy.deepcopy(history)
+    processor = ImageParsingHistoryProcessor()
+    result = processor(history)
+    images = [item for item in result[0]["content"] if item["type"] == "image_url"]
+    assert images == [image, {"type": "image_url", "image_url": {"url": "data:image/png;base64,bmV3"}}]
+    assert history == original
+    assert processor(result) == result
+
+
+def test_image_parsing_preserves_image_only_and_empty_content():
+    processor = ImageParsingHistoryProcessor()
+    for content in ([], [{"type": "image_url", "image_url": {"url": "https://example.com/image.png"}}]):
+        history = [{"role": "user", "content": content, "message_type": "observation"}]
+        assert processor(history) == history

--- a/tests/test_history_processors.py
+++ b/tests/test_history_processors.py
@@ -1,10 +1,9 @@
-import copy
 import json
 from pathlib import Path
 
 import pytest
 
-from sweagent.agent.history_processors import ImageParsingHistoryProcessor, LastNObservations, TagToolCallObservations
+from sweagent.agent.history_processors import LastNObservations, TagToolCallObservations
 from sweagent.types import History
 
 
@@ -39,33 +38,3 @@ def test_add_tag_to_edits(test_history: History):
     for entry in new_history:
         if entry.get("action", "").startswith("edit "):  # type: ignore
             assert entry.get("tags") == ["test"], entry
-
-
-@pytest.mark.parametrize("role", ["user", "tool"])
-def test_image_parsing_preserves_existing_multimodal_content(role):
-    image = {"type": "image_url", "image_url": {"url": "data:image/png;base64,b2xk"}}
-    history = [
-        {
-            "role": role,
-            "content": [
-                {"type": "text", "text": "existing image"},
-                image,
-                {"type": "text", "text": "new image ![new](data:image/png;base64,bmV3)"},
-            ],
-            "message_type": "observation",
-        }
-    ]
-    original = copy.deepcopy(history)
-    processor = ImageParsingHistoryProcessor()
-    result = processor(history)
-    images = [item for item in result[0]["content"] if item["type"] == "image_url"]
-    assert images == [image, {"type": "image_url", "image_url": {"url": "data:image/png;base64,bmV3"}}]
-    assert history == original
-    assert processor(result) == result
-
-
-def test_image_parsing_preserves_image_only_and_empty_content():
-    processor = ImageParsingHistoryProcessor()
-    for content in ([], [{"type": "image_url", "image_url": {"url": "https://example.com/image.png"}}]):
-        history = [{"role": "user", "content": content, "message_type": "observation"}]
-        assert processor(history) == history

--- a/tests/test_image_history.py
+++ b/tests/test_image_history.py
@@ -33,3 +33,24 @@ def test_image_parsing_preserves_image_only_and_empty_content():
     for content in ([], [{"type": "image_url", "image_url": {"url": "https://example.com/image.png"}}]):
         history = [{"role": "user", "content": content, "message_type": "observation"}]
         assert processor(history) == history
+
+
+@pytest.mark.parametrize("role", ["user", "tool"])
+def test_image_parsing_converts_string_input_without_mutation(role):
+    text = "before ![new](data:image/png;base64,bmV3) after"
+    history = [{"role": role, "content": text, "message_type": "observation"}]
+    processor = ImageParsingHistoryProcessor()
+    result = processor(history)
+    assert result[0]["content"] == [
+        {"type": "text", "text": "before ![new](data:"},
+        {"type": "image_url", "image_url": {"url": "data:image/png;base64,bmV3"}},
+        {"type": "text", "text": ") after"},
+    ]
+    assert history[0]["content"] == text
+    assert processor(result) == result
+
+
+@pytest.mark.parametrize("text", ["plain text", "", "![unsupported](data:image/gif;base64,bmV3)"])
+def test_image_parsing_preserves_strings_without_supported_images(text):
+    history = [{"role": "user", "content": text, "message_type": "observation"}]
+    assert ImageParsingHistoryProcessor()(history) == history

--- a/tests/test_image_history.py
+++ b/tests/test_image_history.py
@@ -1,0 +1,35 @@
+import copy
+
+import pytest
+
+from sweagent.agent.history_processors import ImageParsingHistoryProcessor
+
+
+@pytest.mark.parametrize("role", ["user", "tool"])
+def test_image_parsing_preserves_existing_multimodal_content(role):
+    image = {"type": "image_url", "image_url": {"url": "data:image/png;base64,b2xk"}}
+    history = [
+        {
+            "role": role,
+            "content": [
+                {"type": "text", "text": "existing image"},
+                image,
+                {"type": "text", "text": "new image ![new](data:image/png;base64,bmV3)"},
+            ],
+            "message_type": "observation",
+        }
+    ]
+    original = copy.deepcopy(history)
+    processor = ImageParsingHistoryProcessor()
+    result = processor(history)
+    images = [item for item in result[0]["content"] if item["type"] == "image_url"]
+    assert images == [image, {"type": "image_url", "image_url": {"url": "data:image/png;base64,bmV3"}}]
+    assert history == original
+    assert processor(result) == result
+
+
+def test_image_parsing_preserves_image_only_and_empty_content():
+    processor = ImageParsingHistoryProcessor()
+    for content in ([], [{"type": "image_url", "image_url": {"url": "https://example.com/image.png"}}]):
+        history = [{"role": "user", "content": content, "message_type": "observation"}]
+        assert processor(history) == history


### PR DESCRIPTION
The image-parsing history processor asserts that every user/tool message contains a single text block. Existing multimodal problem statements, image-only messages, or already-processed history therefore crash before reaching the model. Parse embedded images in each text block and preserve existing image blocks and other content.

Validation: all 5 history-processor tests pass. Three regressions fail on current main and cover user/tool multimodal messages, existing plus newly embedded images, image-only/empty content, repeat processing, and preservation of the original history. Ruff check/format and `git diff --check` pass.


Validation update: Added string-input coverage for user/tool images, unchanged plain/empty strings, and unsupported MIME types after the Codecov comment. The image/history tests now pass 10 tests; Ruff and formatting pass. New head 5e97c9f awaits refreshed CI.
