### PR TITLE
fix(batch): isolate deterministic shuffling from global randomness

### DIFF
--- a/sweagent/run/batch_instances.py
+++ b/sweagent/run/batch_instances.py
@@ -69,8 +69,7 @@ def _filter_batch_items(
 ) -> list[BatchInstance]:
     if shuffle:
         instances = sorted(instances.copy(), key=lambda x: x.problem_statement.id)
-        random.seed(42)
-        random.shuffle(instances)
+        random.Random(42).shuffle(instances)
     before_filter = len(instances)
     instances = [instance for instance in instances if re.match(filter_, instance.problem_statement.id)]
     after_filter = len(instances)

--- a/tests/test_batch_instance.py
+++ b/tests/test_batch_instance.py
@@ -66,3 +66,26 @@ def test_get_swe_bench_instances():
             instances = instance_config.get_instance_configs()
             assert len(instances) > 0
             assert all(isinstance(instance, BatchInstance) for instance in instances)
+
+
+def test_batch_shuffle_preserves_global_random_state():
+    import random
+
+    from sweagent.run.batch_instances import _filter_batch_items
+
+    instances = [
+        SimpleBatchInstance(
+            image_name="python:3.11", problem_statement="Fix", instance_id=str(i)
+        ).to_full_batch_instance(DockerDeploymentConfig(image="python:3.11"))
+        for i in range(10)
+    ]
+    original_ids = [item.problem_statement.id for item in instances]
+    random_state = random.getstate()
+    try:
+        shuffled = _filter_batch_items(instances, filter_=".*", shuffle=True)
+        assert random.getstate() == random_state
+        assert [item.problem_statement.id for item in shuffled] == ["7", "3", "2", "8", "5", "6", "9", "4", "0", "1"]
+        assert [item.problem_statement.id for item in instances] == original_ids
+        assert _filter_batch_items(list(reversed(instances)), filter_=".*", shuffle=True) == shuffled
+    finally:
+        random.setstate(random_state)

--- a/tests/test_batch_instance.py
+++ b/tests/test_batch_instance.py
@@ -66,26 +66,3 @@ def test_get_swe_bench_instances():
             instances = instance_config.get_instance_configs()
             assert len(instances) > 0
             assert all(isinstance(instance, BatchInstance) for instance in instances)
-
-
-def test_batch_shuffle_preserves_global_random_state():
-    import random
-
-    from sweagent.run.batch_instances import _filter_batch_items
-
-    instances = [
-        SimpleBatchInstance(
-            image_name="python:3.11", problem_statement="Fix", instance_id=str(i)
-        ).to_full_batch_instance(DockerDeploymentConfig(image="python:3.11"))
-        for i in range(10)
-    ]
-    original_ids = [item.problem_statement.id for item in instances]
-    random_state = random.getstate()
-    try:
-        shuffled = _filter_batch_items(instances, filter_=".*", shuffle=True)
-        assert random.getstate() == random_state
-        assert [item.problem_statement.id for item in shuffled] == ["7", "3", "2", "8", "5", "6", "9", "4", "0", "1"]
-        assert [item.problem_statement.id for item in instances] == original_ids
-        assert _filter_batch_items(list(reversed(instances)), filter_=".*", shuffle=True) == shuffled
-    finally:
-        random.setstate(random_state)

--- a/tests/test_batch_shuffle.py
+++ b/tests/test_batch_shuffle.py
@@ -1,0 +1,26 @@
+from swerex.deployment.config import DockerDeploymentConfig
+
+from sweagent.run.batch_instances import SimpleBatchInstance
+
+
+def test_batch_shuffle_preserves_global_random_state():
+    import random
+
+    from sweagent.run.batch_instances import _filter_batch_items
+
+    instances = [
+        SimpleBatchInstance(
+            image_name="python:3.11", problem_statement="Fix", instance_id=str(i)
+        ).to_full_batch_instance(DockerDeploymentConfig(image="python:3.11"))
+        for i in range(10)
+    ]
+    original_ids = [item.problem_statement.id for item in instances]
+    random_state = random.getstate()
+    try:
+        shuffled = _filter_batch_items(instances, filter_=".*", shuffle=True)
+        assert random.getstate() == random_state
+        assert [item.problem_statement.id for item in shuffled] == ["7", "3", "2", "8", "5", "6", "9", "4", "0", "1"]
+        assert [item.problem_statement.id for item in instances] == original_ids
+        assert _filter_batch_items(list(reversed(instances)), filter_=".*", shuffle=True) == shuffled
+    finally:
+        random.setstate(random_state)


### PR DESCRIPTION
Batch shuffling currently calls `random.seed(42)` on the process-wide generator. Loading a shuffled dataset therefore resets randomness used by model API-key selection, request jitter, and worker delays. Use a dedicated `Random(42)` instance so dataset order remains reproducible without changing the caller's random state.

Validation: 7 non-network batch-instance tests passed; the new regression fails on the original code and checks unchanged global state, unchanged input order, and deterministic output independent of input order. Ruff lint and formatting passed.
