### PR TITLE
fix(github): match complete issue closing references

### DIFF
--- a/sweagent/utils/github.py
+++ b/sweagent/utils/github.py
@@ -114,6 +114,7 @@ def _get_associated_commit_urls(org: str, repo: str, issue_number: str, *, token
     # so we have to go through the events to check if there's a commit
     events = api.issues.list_events(org, repo, issue_number)  # type: ignore
     commit_urls = []
+    closing_reference = re.compile(rf"\b(?:fixes|closes)\s+#{re.escape(issue_number)}\b", re.IGNORECASE)
     for event in events:
         if event.event != "referenced":
             continue
@@ -121,7 +122,7 @@ def _get_associated_commit_urls(org: str, repo: str, issue_number: str, *, token
             continue
         commit = api.repos.get_commit(org, repo, event.commit_id)  # type: ignore
         message = commit.commit.message
-        if f"fixes #{issue_number}" in message.lower() or f"closes #{issue_number}" in message.lower():
+        if closing_reference.search(message):
             commit_urls.append(commit.html_url)
     return commit_urls
 

--- a/tests/test_env_utils.py
+++ b/tests/test_env_utils.py
@@ -92,29 +92,3 @@ def clone_repo(tmp_path, repo_url):
         repo_url,
     ]
     subprocess.run(cmd, check=True, cwd=tmp_path)
-
-
-@pytest.mark.parametrize(
-    ("message", "closes_issue"),
-    [
-        ("fixes #12", True),
-        ("Closes #12.", True),
-        ("Subject\n\nFIXES #12\n", True),
-        ("fixes #123", False),
-        ("closes #120", False),
-        ("prefixes #12", False),
-        ("mentions #12", False),
-    ],
-)
-def test_associated_commit_requires_exact_closing_reference(monkeypatch, message, closes_issue):
-    from types import SimpleNamespace
-    from unittest.mock import Mock
-
-    api = Mock()
-    api.issues.list_events.return_value = [SimpleNamespace(event="referenced", commit_id="abc")]
-    api.repos.get_commit.return_value = SimpleNamespace(
-        commit=SimpleNamespace(message=message), html_url="https://github.com/owner/repo/commit/abc"
-    )
-    monkeypatch.setattr("sweagent.utils.github.GhApi", lambda **kwargs: api)
-    result = _get_associated_commit_urls("owner", "repo", "12")
-    assert result == (["https://github.com/owner/repo/commit/abc"] if closes_issue else [])

--- a/tests/test_env_utils.py
+++ b/tests/test_env_utils.py
@@ -92,3 +92,29 @@ def clone_repo(tmp_path, repo_url):
         repo_url,
     ]
     subprocess.run(cmd, check=True, cwd=tmp_path)
+
+
+@pytest.mark.parametrize(
+    ("message", "closes_issue"),
+    [
+        ("fixes #12", True),
+        ("Closes #12.", True),
+        ("Subject\n\nFIXES #12\n", True),
+        ("fixes #123", False),
+        ("closes #120", False),
+        ("prefixes #12", False),
+        ("mentions #12", False),
+    ],
+)
+def test_associated_commit_requires_exact_closing_reference(monkeypatch, message, closes_issue):
+    from types import SimpleNamespace
+    from unittest.mock import Mock
+
+    api = Mock()
+    api.issues.list_events.return_value = [SimpleNamespace(event="referenced", commit_id="abc")]
+    api.repos.get_commit.return_value = SimpleNamespace(
+        commit=SimpleNamespace(message=message), html_url="https://github.com/owner/repo/commit/abc"
+    )
+    monkeypatch.setattr("sweagent.utils.github.GhApi", lambda **kwargs: api)
+    result = _get_associated_commit_urls("owner", "repo", "12")
+    assert result == (["https://github.com/owner/repo/commit/abc"] if closes_issue else [])

--- a/tests/test_github_closing_refs.py
+++ b/tests/test_github_closing_refs.py
@@ -1,0 +1,29 @@
+import pytest
+
+from sweagent.utils.github import _get_associated_commit_urls
+
+
+@pytest.mark.parametrize(
+    ("message", "closes_issue"),
+    [
+        ("fixes #12", True),
+        ("Closes #12.", True),
+        ("Subject\n\nFIXES #12\n", True),
+        ("fixes #123", False),
+        ("closes #120", False),
+        ("prefixes #12", False),
+        ("mentions #12", False),
+    ],
+)
+def test_associated_commit_requires_exact_closing_reference(monkeypatch, message, closes_issue):
+    from types import SimpleNamespace
+    from unittest.mock import Mock
+
+    api = Mock()
+    api.issues.list_events.return_value = [SimpleNamespace(event="referenced", commit_id="abc")]
+    api.repos.get_commit.return_value = SimpleNamespace(
+        commit=SimpleNamespace(message=message), html_url="https://github.com/owner/repo/commit/abc"
+    )
+    monkeypatch.setattr("sweagent.utils.github.GhApi", lambda **kwargs: api)
+    result = _get_associated_commit_urls("owner", "repo", "12")
+    assert result == (["https://github.com/owner/repo/commit/abc"] if closes_issue else [])


### PR DESCRIPTION
The existing substring check treats a commit saying `fixes #123` as a fix for issue `#12`, and even treats `prefixes #12` as a closing keyword. That can make the PR hook skip a valid submission because it believes another commit already fixes the issue. Match complete closing keywords and the complete issue number, preserving case-insensitive matching.

Validation: 15 offline environment utility tests passed, including seven mocked GitHub commit-message cases; three negative controls fail on the original implementation. The existing live GitHub integration test was excluded. Ruff lint and formatting passed.
