### PR TITLE
fix(tools): reject empty edit search before replacement

### DIFF
--- a/tests/tools/test_default_utils.py
+++ b/tests/tools/test_default_utils.py
@@ -151,3 +151,10 @@ def test_print_window_new_file(with_tmp_env_file, capsys):
     print(captured.out)
     expected = _DEFAULT_WINDOW_OUTPUT_NEW_FILE.format(path=wfile.path.resolve())
     assert captured.out == expected
+
+
+def test_find_all_rejects_empty_search():
+    from windowed_file import _find_all
+
+    with pytest.raises(ValueError, match="Search text must not be empty"):
+        next(_find_all("some content", ""))

--- a/tests/tools/test_edit_replace.py
+++ b/tests/tools/test_edit_replace.py
@@ -1,4 +1,5 @@
 import importlib
+from unittest.mock import Mock
 
 import pytest
 
@@ -17,12 +18,11 @@ def test_edit_rejects_empty_search_before_linting(with_tmp_env_file, tmp_path, c
     registry["WINDOW"] = "10"
     registry["FIRST_LINE"] = "0"
 
-    def unexpected_lint(*args, **kwargs):
-        pytest.fail("Empty search must be rejected before linting or replacement")
-
-    monkeypatch.setattr(edit, "flake8", unexpected_lint)
+    lint = Mock()
+    monkeypatch.setattr(edit, "flake8", lint)
     with pytest.raises(SystemExit) as error:
         edit.main("", "new", True)
+    lint.assert_not_called()
     assert error.value.code == 2
     output = capsys.readouterr().out
     assert "Search text must not be empty" in output

--- a/tests/tools/test_edit_replace.py
+++ b/tests/tools/test_edit_replace.py
@@ -1,0 +1,30 @@
+import importlib
+
+import pytest
+
+from sweagent import TOOLS_DIR
+from tests.utils import make_python_tool_importable
+
+
+def test_edit_rejects_empty_search_before_linting(with_tmp_env_file, tmp_path, capsys, monkeypatch):
+    make_python_tool_importable(TOOLS_DIR / "windowed_edit_replace/bin/edit", "edit_replace")
+    edit = importlib.import_module("edit_replace")
+    from registry import registry
+
+    path = tmp_path / "example.py"
+    path.write_text("original = 1\n")
+    registry["CURRENT_FILE"] = str(path)
+    registry["WINDOW"] = "10"
+    registry["FIRST_LINE"] = "0"
+
+    def unexpected_lint(*args, **kwargs):
+        pytest.fail("Empty search must be rejected before linting or replacement")
+
+    monkeypatch.setattr(edit, "flake8", unexpected_lint)
+    with pytest.raises(SystemExit) as error:
+        edit.main("", "new", True)
+    assert error.value.code == 2
+    output = capsys.readouterr().out
+    assert "Search text must not be empty" in output
+    assert edit.RETRY_WITH_OUTPUT_TOKEN in output
+    assert path.read_text() == "original = 1\n"

--- a/tools/windowed/lib/windowed_file.py
+++ b/tools/windowed/lib/windowed_file.py
@@ -24,6 +24,8 @@ class TextNotFound(Exception):
 
 
 def _find_all(a_str: str, sub: str):
+    if not sub:
+        raise ValueError("Search text must not be empty")
     start = 0
     while True:
         start = a_str.find(sub, start)

--- a/tools/windowed_edit_replace/bin/edit
+++ b/tools/windowed_edit_replace/bin/edit
@@ -94,6 +94,11 @@ def main(search: str, replace: str, replace_all: bool):
     # Turn \\n into \n etc., i.e., undo the escaping
     # args.replace = args.replace.encode("utf8").decode("unicode_escape")
 
+    if not search:
+        print("Search text must not be empty. Use insert to add new text.")
+        print(RETRY_WITH_OUTPUT_TOKEN)
+        exit(2)
+
     if search == replace:
         print(_NO_CHANGES_MADE_MSG)
         print(RETRY_WITH_OUTPUT_TOKEN)


### PR DESCRIPTION
An empty search string with replace-all enabled causes `_find_all` to yield position zero indefinitely, so the edit hangs and keeps growing its list of matches. Reject empty searches before linting/replacement with the existing retry-output marker and an actionable message pointing to insert. The helper also rejects empty needles so direct callers cannot enter the same loop.

Validation: all 8 windowed-tool tests pass. Both added regressions fail on main: a bounded first-yield test exposes the non-advancing iterator without hanging the suite, and an edit entry-point test verifies rejection before linting and unchanged file contents. Ruff and `git diff --check` pass.


Validation update: Replaced the intentionally unreachable pytest.fail guard with a mock and explicit assert_not_called assertion after the Codecov comment. All 8 targeted tool tests pass; Ruff and formatting pass. New head 2195eb4 awaits refreshed CI.
