### PR TITLE
fix(parser): reject reversed XML command tags

### DIFF
--- a/sweagent/tools/parsing.py
+++ b/sweagent/tools/parsing.py
@@ -208,6 +208,9 @@ class XMLThoughtActionParser(AbstractParseFunction, BaseModel):
         )  # start after the last <command> tag
         end_thought = model_response["message"].rfind("<command>")  # end before the last <command> tag
         end_action = model_response["message"].rfind("</command>")  # end before the last </command> tag
+        if end_action < start_action:
+            msg = "The final <command> tag has no matching closing tag."
+            raise FormatError(msg)
         restart_thought = model_response["message"].rfind("</command>") + len(
             "</command>"
         )  # start after the last </command> tag

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -129,3 +129,17 @@ def test_function_calling_parser_error_message():
     template = Template(FunctionCallingParser().error_message)
     exc1 = FunctionCallingFormatError("test", "missing")
     assert "did not use any tool calls" in template.render(**exc1.extra_info, exception_message=exc1.message)
+
+
+@pytest.mark.parametrize("message", ["</command>ls<command>", "<command>ls</command>unfinished<command>"])
+def test_xml_thought_action_rejects_reversed_final_tags(message):
+    with pytest.raises(FormatError):
+        XMLThoughtActionParser()({"message": message}, [])
+
+
+def test_xml_thought_action_uses_last_complete_command():
+    thought, action = XMLThoughtActionParser()(
+        {"message": "earlier <command>pwd</command> then <command>ls</command> done"}, []
+    )
+    assert action == "ls"
+    assert thought == "earlier <command>pwd</command> then  done"


### PR DESCRIPTION
If the final `<command>` appears after the final `</command>`, XMLThoughtActionParser returns an empty action instead of a recoverable format error. Reject the reversed final tag pair, including a trailing unclosed command after an earlier complete block, so the agent can request corrected output.

Validation: all 11 parser tests pass. Two new malformed-response cases fail on current main; a third verifies that multiple complete blocks retain the existing last-command selection. Ruff check/format and `git diff --check` pass.
