### PR TITLE
fix(run): keep trajectory truncation notices within the size limit

### DIFF
--- a/sweagent/run/hooks/open_pr.py
+++ b/sweagent/run/hooks/open_pr.py
@@ -211,6 +211,8 @@ def format_trajectory_markdown(trajectory: list[dict[str, str]], char_limit: int
 
     steps = []
     current_length = len(prefix_text) + len(suffix_text)
+    if char_limit is not None and current_length > char_limit:
+        return ""
 
     for i, step in enumerate(trajectory):
         step_strs = [
@@ -230,8 +232,12 @@ def format_trajectory_markdown(trajectory: list[dict[str, str]], char_limit: int
 
         # Check if adding this step would exceed the character limit
         if char_limit is not None and current_length + separator_length + len(step_text) > char_limit:
-            if i > 0:
-                steps.append("\n\n... (truncated due to length limit)")
+            marker = "\n\n... (truncated due to length limit)"
+            # Make room for the marker without cutting through a step's code fence.
+            while steps and current_length + len(marker) > char_limit:
+                current_length -= len(steps.pop())
+            if current_length + len(marker) <= char_limit:
+                steps.append(marker)
             break
 
         if steps:

--- a/tests/test_env_utils.py
+++ b/tests/test_env_utils.py
@@ -92,3 +92,24 @@ def clone_repo(tmp_path, repo_url):
         repo_url,
     ]
     subprocess.run(cmd, check=True, cwd=tmp_path)
+
+
+def test_format_trajectory_reserves_truncation_marker_budget():
+    first = {"response": "first step", "observation": "first result"}
+    second = {"response": "second step " * 100, "observation": "second result"}
+    limit = len(format_trajectory_markdown([first]))
+    formatted = format_trajectory_markdown([first, second], char_limit=limit)
+    assert len(formatted) <= limit
+    assert formatted.startswith("<details>")
+    assert formatted.endswith("</details>")
+    assert "truncated" in formatted
+
+
+def test_format_trajectory_omits_wrapper_when_budget_cannot_hold_it():
+    assert format_trajectory_markdown([], char_limit=0) == ""
+
+
+def test_format_trajectory_preserves_output_at_exact_limit():
+    trajectory = [{"response": "done", "observation": "ok"}]
+    full = format_trajectory_markdown(trajectory)
+    assert format_trajectory_markdown(trajectory, char_limit=len(full)) == full

--- a/tests/test_env_utils.py
+++ b/tests/test_env_utils.py
@@ -92,24 +92,3 @@ def clone_repo(tmp_path, repo_url):
         repo_url,
     ]
     subprocess.run(cmd, check=True, cwd=tmp_path)
-
-
-def test_format_trajectory_reserves_truncation_marker_budget():
-    first = {"response": "first step", "observation": "first result"}
-    second = {"response": "second step " * 100, "observation": "second result"}
-    limit = len(format_trajectory_markdown([first]))
-    formatted = format_trajectory_markdown([first, second], char_limit=limit)
-    assert len(formatted) <= limit
-    assert formatted.startswith("<details>")
-    assert formatted.endswith("</details>")
-    assert "truncated" in formatted
-
-
-def test_format_trajectory_omits_wrapper_when_budget_cannot_hold_it():
-    assert format_trajectory_markdown([], char_limit=0) == ""
-
-
-def test_format_trajectory_preserves_output_at_exact_limit():
-    trajectory = [{"response": "done", "observation": "ok"}]
-    full = format_trajectory_markdown(trajectory)
-    assert format_trajectory_markdown(trajectory, char_limit=len(full)) == full

--- a/tests/test_trajectory_markdown.py
+++ b/tests/test_trajectory_markdown.py
@@ -1,0 +1,22 @@
+from sweagent.run.hooks.open_pr import format_trajectory_markdown
+
+
+def test_format_trajectory_reserves_truncation_marker_budget():
+    first = {"response": "first step", "observation": "first result"}
+    second = {"response": "second step " * 100, "observation": "second result"}
+    limit = len(format_trajectory_markdown([first]))
+    formatted = format_trajectory_markdown([first, second], char_limit=limit)
+    assert len(formatted) <= limit
+    assert formatted.startswith("<details>")
+    assert formatted.endswith("</details>")
+    assert "truncated" in formatted
+
+
+def test_format_trajectory_omits_wrapper_when_budget_cannot_hold_it():
+    assert format_trajectory_markdown([], char_limit=0) == ""
+
+
+def test_format_trajectory_preserves_output_at_exact_limit():
+    trajectory = [{"response": "done", "observation": "ok"}]
+    full = format_trajectory_markdown(trajectory)
+    assert format_trajectory_markdown(trajectory, char_limit=len(full)) == full


### PR DESCRIPTION
When a trajectory step fits exactly within `char_limit` and a later step does not fit, the formatter adds a truncation notice outside the budget. The returned Markdown can therefore exceed the requested limit. Count the notice in that budget, removing only complete steps when necessary so code fences remain intact. Return an empty string when even the details wrapper does not fit.

Validation: 11 offline environment utility tests passed. New regressions reproduce the original overrun and zero-budget failure and preserve exact-limit output. The live GitHub integration test was excluded. Ruff lint and formatting passed.
