### PR TITLE
fix(tools): preserve leading blank lines when inserting

### DIFF
--- a/tests/tools/test_default_utils.py
+++ b/tests/tools/test_default_utils.py
@@ -151,3 +151,12 @@ def test_print_window_new_file(with_tmp_env_file, capsys):
     print(captured.out)
     expected = _DEFAULT_WINDOW_OUTPUT_NEW_FILE.format(path=wfile.path.resolve())
     assert captured.out == expected
+
+
+@pytest.mark.parametrize("content", ["\noriginal", "\n\noriginal", "original", ""])
+def test_insert_at_start_preserves_existing_blank_lines(with_tmp_env_file, content):
+    wfile = create_test_file_with_content(with_tmp_env_file, content)
+    info = wfile.insert("new", line=-1)
+    assert wfile.text == ("new\n" + content if content else "new")
+    assert info.first_inserted_line == 0
+    assert info.n_lines_added == 1

--- a/tests/tools/test_default_utils.py
+++ b/tests/tools/test_default_utils.py
@@ -151,12 +151,3 @@ def test_print_window_new_file(with_tmp_env_file, capsys):
     print(captured.out)
     expected = _DEFAULT_WINDOW_OUTPUT_NEW_FILE.format(path=wfile.path.resolve())
     assert captured.out == expected
-
-
-@pytest.mark.parametrize("content", ["\noriginal", "\n\noriginal", "original", ""])
-def test_insert_at_start_preserves_existing_blank_lines(with_tmp_env_file, content):
-    wfile = create_test_file_with_content(with_tmp_env_file, content)
-    info = wfile.insert("new", line=-1)
-    assert wfile.text == ("new\n" + content if content else "new")
-    assert info.first_inserted_line == 0
-    assert info.n_lines_added == 1

--- a/tests/tools/test_windowed_insert.py
+++ b/tests/tools/test_windowed_insert.py
@@ -1,0 +1,12 @@
+import pytest
+
+from tests.tools.test_default_utils import create_test_file_with_content
+
+
+@pytest.mark.parametrize("content", ["\noriginal", "\n\noriginal", "original", ""])
+def test_insert_at_start_preserves_existing_blank_lines(with_tmp_env_file, content):
+    wfile = create_test_file_with_content(with_tmp_env_file, content)
+    info = wfile.insert("new", line=-1)
+    assert wfile.text == ("new\n" + content if content else "new")
+    assert info.first_inserted_line == 0
+    assert info.n_lines_added == 1

--- a/tools/windowed/lib/windowed_file.py
+++ b/tools/windowed/lib/windowed_file.py
@@ -298,8 +298,7 @@ class WindowedFile:
             if not self.text:
                 new_text = text
             else:
-                current_text = self.text[1:] if self.text.startswith("\n") else self.text
-                new_text = text + "\n" + current_text
+                new_text = text + "\n" + self.text
             insert_line = 0
         else:
             # Insert at specific line


### PR DESCRIPTION
Inserting at the start of a file with a negative line number discarded its first existing newline. A file beginning with one or more blank lines therefore lost content outside the inserted text. Preserve the original contents after the new line, matching insertion at index zero.

Validation: all 10 windowed-file tests pass. The new parameterized regression covers one/two leading blank lines, ordinary content, and an empty file; the two leading-blank cases fail on main. It also verifies inserted-line metadata. Ruff check/format and `git diff --check` pass.
