### PR TITLE
fix(models): preserve Unicode in human command input

### DIFF
--- a/sweagent/agent/models.py
+++ b/sweagent/agent/models.py
@@ -412,7 +412,7 @@ class HumanModel(AbstractModel):
             action = "\n".join(buffer)
         else:
             # Input has escaped things like \n, so we need to unescape it
-            action = action.encode("utf8").decode("unicode_escape")
+            action = action.encode("raw_unicode_escape").decode("unicode_escape")
         if action.strip() and action.strip().split()[0] == "spend_money":
             money = float(action.strip().split()[1])
             self.stats.instance_cost += money

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
+import pytest
 from pydantic import SecretStr
 
 from sweagent import __version__
@@ -104,3 +105,15 @@ def test_user_agent_header_with_other_extra_headers():
         extra_headers = call_kwargs.kwargs.get("extra_headers", {})
         assert extra_headers["User-Agent"] == f"swe-agent/{__version__}"
         assert extra_headers["X-Custom"] == "value"
+
+
+@pytest.mark.parametrize("action", ["echo café", "cat 文档.txt", "echo 😀", "echo café\\necho résumé"])
+def test_human_model_preserves_unicode_when_unescaping(action, monkeypatch):
+    from sweagent.agent.models import HumanModel, HumanModelConfig
+    from sweagent.tools.tools import ToolConfig
+
+    monkeypatch.setattr(HumanModel, "_load_readline_history", lambda self: None)
+    monkeypatch.setattr(HumanModel, "_save_readline_history", lambda self: None)
+    monkeypatch.setattr("builtins.input", lambda prompt: action)
+    model = HumanModel(HumanModelConfig(), ToolConfig())
+    assert model.query([])["message"] == action.replace("\\n", "\n")


### PR DESCRIPTION
Single-line human commands were UTF-8 encoded and then decoded as Python byte escapes, so non-ASCII text became mojibake before being sent to the shell (for example `cat 文档.txt`). Use raw Unicode escape encoding to preserve entered Unicode while retaining the existing backslash-escape handling.

Validation: all 8 model tests pass. Four new regressions fail on main and cover accented filenames/text, Chinese, emoji, and a command combining accented text with an escaped newline. Input/readline persistence is mocked; command processing and model accounting run through HumanModel.query. Ruff check/format and `git diff --check` pass.
