### PR TITLE
fix(images): close streamed responses after processing or rejection

### DIFF
--- a/sweagent/agent/problem_statement.py
+++ b/sweagent/agent/problem_statement.py
@@ -2,6 +2,7 @@ import base64
 import hashlib
 import os
 import uuid
+from contextlib import closing
 from pathlib import Path
 from typing import Any, Literal, Protocol
 from urllib.parse import urlparse
@@ -235,33 +236,33 @@ class SWEBenchMultimodalProblemStatement(_BuiltinProblemStatementBase):
             headers = {
                 "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.5735.133 Safari/537.36"
             }
-            response = requests.get(url, headers=headers, timeout=30, stream=True)
-            response.raise_for_status()
-            # strip any media type parameters (e.g. "image/png; charset=utf-8") before validation
-            content_type = response.headers.get("content-type", "").split(";")[0].strip().lower()
-            if content_type == "image/jpg":
-                content_type = "image/jpeg"
-            if content_type not in VALID_IMAGE_MIME_TYPES:
-                logger.warning(f"Unsupported image MIME type '{content_type}' for URL: {url}. Not encoding image.")
-                return None
-            max_size = 10 * 1024 * 1024  # 10MB
-            content_length = response.headers.get("content-length")
-            if content_length and int(content_length) > max_size:
-                logger.warning(f"Image too large ({content_length} bytes) for URL: {url}")
-                return None
-            image_data = b""
-            for chunk in response.iter_content(chunk_size=8192):
-                image_data += chunk
-                if len(image_data) > max_size:
-                    logger.warning(f"Image too large (>{max_size} bytes) for URL: {url}")
+            with closing(requests.get(url, headers=headers, timeout=30, stream=True)) as response:
+                response.raise_for_status()
+                # strip any media type parameters (e.g. "image/png; charset=utf-8") before validation
+                content_type = response.headers.get("content-type", "").split(";")[0].strip().lower()
+                if content_type == "image/jpg":
+                    content_type = "image/jpeg"
+                if content_type not in VALID_IMAGE_MIME_TYPES:
+                    logger.warning(f"Unsupported image MIME type '{content_type}' for URL: {url}. Not encoding image.")
                     return None
-            if not image_data:
-                logger.warning(f"Empty image data for URL: {url}")
-                return None
-            b64_data = base64.b64encode(image_data).decode("ascii")
-            markdown = f"![{url}](data:{content_type};base64,{b64_data})"
-            logger.info(f"Successfully processed image from {url} ({len(image_data)} bytes, {content_type})")
-            return markdown
+                max_size = 10 * 1024 * 1024  # 10MB
+                content_length = response.headers.get("content-length")
+                if content_length and int(content_length) > max_size:
+                    logger.warning(f"Image too large ({content_length} bytes) for URL: {url}")
+                    return None
+                image_data = b""
+                for chunk in response.iter_content(chunk_size=8192):
+                    image_data += chunk
+                    if len(image_data) > max_size:
+                        logger.warning(f"Image too large (>{max_size} bytes) for URL: {url}")
+                        return None
+                if not image_data:
+                    logger.warning(f"Empty image data for URL: {url}")
+                    return None
+                b64_data = base64.b64encode(image_data).decode("ascii")
+                markdown = f"![{url}](data:{content_type};base64,{b64_data})"
+                logger.info(f"Successfully processed image from {url} ({len(image_data)} bytes, {content_type})")
+                return markdown
 
         except requests.exceptions.Timeout:
             logger.warning(f"Timeout downloading image from {url}")

--- a/tests/test_image_response_lifecycle.py
+++ b/tests/test_image_response_lifecycle.py
@@ -6,12 +6,34 @@ import requests
 from sweagent.agent.problem_statement import SWEBenchMultimodalProblemStatement
 
 
-@pytest.mark.parametrize("scenario", ["success", "mime", "declared_size", "stream_size", "stream_error", "http_error"])
+@pytest.mark.parametrize(
+    "scenario",
+    [
+        "success",
+        "jpg",
+        "empty",
+        "mime",
+        "declared_size",
+        "invalid_length",
+        "stream_size",
+        "stream_error",
+        "stream_timeout",
+        "http_error",
+    ],
+)
 def test_image_download_closes_streamed_response(monkeypatch, scenario):
     response = Mock()
     response.headers = {"content-type": "image/png"}
     response.iter_content.return_value = [b"image data"]
-    if scenario == "mime":
+    if scenario == "jpg":
+        response.headers["content-type"] = "image/jpg; charset=utf-8"
+    elif scenario == "empty":
+        response.iter_content.return_value = []
+    elif scenario == "invalid_length":
+        response.headers["content-length"] = "invalid"
+    elif scenario == "stream_timeout":
+        response.iter_content.side_effect = requests.exceptions.Timeout("stream stalled")
+    elif scenario == "mime":
         response.headers["content-type"] = "text/html"
     elif scenario == "declared_size":
         response.headers["content-length"] = str(11 * 1024 * 1024)
@@ -24,5 +46,7 @@ def test_image_download_closes_streamed_response(monkeypatch, scenario):
     monkeypatch.setattr("requests.get", lambda *args, **kwargs: response)
     statement = SWEBenchMultimodalProblemStatement(text="problem")
     result = statement._download_and_convert_image("https://example.com/image.png")
-    assert (result is not None) == (scenario == "success")
+    assert (result is not None) == (scenario in {"success", "jpg"})
+    if scenario == "jpg":
+        assert "data:image/jpeg;base64," in result
     response.close.assert_called_once_with()

--- a/tests/test_image_response_lifecycle.py
+++ b/tests/test_image_response_lifecycle.py
@@ -1,0 +1,28 @@
+from unittest.mock import Mock
+
+import pytest
+import requests
+
+from sweagent.agent.problem_statement import SWEBenchMultimodalProblemStatement
+
+
+@pytest.mark.parametrize("scenario", ["success", "mime", "declared_size", "stream_size", "stream_error", "http_error"])
+def test_image_download_closes_streamed_response(monkeypatch, scenario):
+    response = Mock()
+    response.headers = {"content-type": "image/png"}
+    response.iter_content.return_value = [b"image data"]
+    if scenario == "mime":
+        response.headers["content-type"] = "text/html"
+    elif scenario == "declared_size":
+        response.headers["content-length"] = str(11 * 1024 * 1024)
+    elif scenario == "stream_size":
+        response.iter_content.return_value = [b"x" * (10 * 1024 * 1024 + 1)]
+    elif scenario == "stream_error":
+        response.iter_content.side_effect = requests.exceptions.ConnectionError("stream interrupted")
+    elif scenario == "http_error":
+        response.raise_for_status.side_effect = requests.exceptions.HTTPError("not found")
+    monkeypatch.setattr("requests.get", lambda *args, **kwargs: response)
+    statement = SWEBenchMultimodalProblemStatement(text="problem")
+    result = statement._download_and_convert_image("https://example.com/image.png")
+    assert (result is not None) == (scenario == "success")
+    response.close.assert_called_once_with()

--- a/tests/test_problem_statement_multimodal.py
+++ b/tests/test_problem_statement_multimodal.py
@@ -1,6 +1,5 @@
 from unittest.mock import Mock, patch
 
-import pytest
 import requests
 
 from sweagent.agent.problem_statement import SWEBenchMultimodalProblemStatement
@@ -127,25 +126,3 @@ class TestSWEBenchMultimodalProblemStatement:
 
         result = problem_statement.get_problem_statement()
         assert result == "Test problem statement"
-
-
-@pytest.mark.parametrize("scenario", ["success", "mime", "declared_size", "stream_size", "stream_error", "http_error"])
-def test_image_download_closes_streamed_response(monkeypatch, scenario):
-    response = Mock()
-    response.headers = {"content-type": "image/png"}
-    response.iter_content.return_value = [b"image data"]
-    if scenario == "mime":
-        response.headers["content-type"] = "text/html"
-    elif scenario == "declared_size":
-        response.headers["content-length"] = str(11 * 1024 * 1024)
-    elif scenario == "stream_size":
-        response.iter_content.return_value = [b"x" * (10 * 1024 * 1024 + 1)]
-    elif scenario == "stream_error":
-        response.iter_content.side_effect = requests.exceptions.ConnectionError("stream interrupted")
-    elif scenario == "http_error":
-        response.raise_for_status.side_effect = requests.exceptions.HTTPError("not found")
-    monkeypatch.setattr("requests.get", lambda *args, **kwargs: response)
-    statement = SWEBenchMultimodalProblemStatement(text="problem")
-    result = statement._download_and_convert_image("https://example.com/image.png")
-    assert (result is not None) == (scenario == "success")
-    response.close.assert_called_once_with()

--- a/tests/test_problem_statement_multimodal.py
+++ b/tests/test_problem_statement_multimodal.py
@@ -1,5 +1,6 @@
 from unittest.mock import Mock, patch
 
+import pytest
 import requests
 
 from sweagent.agent.problem_statement import SWEBenchMultimodalProblemStatement
@@ -126,3 +127,25 @@ class TestSWEBenchMultimodalProblemStatement:
 
         result = problem_statement.get_problem_statement()
         assert result == "Test problem statement"
+
+
+@pytest.mark.parametrize("scenario", ["success", "mime", "declared_size", "stream_size", "stream_error", "http_error"])
+def test_image_download_closes_streamed_response(monkeypatch, scenario):
+    response = Mock()
+    response.headers = {"content-type": "image/png"}
+    response.iter_content.return_value = [b"image data"]
+    if scenario == "mime":
+        response.headers["content-type"] = "text/html"
+    elif scenario == "declared_size":
+        response.headers["content-length"] = str(11 * 1024 * 1024)
+    elif scenario == "stream_size":
+        response.iter_content.return_value = [b"x" * (10 * 1024 * 1024 + 1)]
+    elif scenario == "stream_error":
+        response.iter_content.side_effect = requests.exceptions.ConnectionError("stream interrupted")
+    elif scenario == "http_error":
+        response.raise_for_status.side_effect = requests.exceptions.HTTPError("not found")
+    monkeypatch.setattr("requests.get", lambda *args, **kwargs: response)
+    statement = SWEBenchMultimodalProblemStatement(text="problem")
+    result = statement._download_and_convert_image("https://example.com/image.png")
+    assert (result is not None) == (scenario == "success")
+    response.close.assert_called_once_with()


### PR DESCRIPTION
Image downloads use `stream=True`, but early returns for unsupported MIME types or excessive sizes leave the response unclosed. HTTP and streaming errors take the same path. Close each obtained response deterministically so rejected image bodies do not retain transport resources; successful image encoding remains unchanged.

Validation: all 19 focused multimodal and response-lifecycle tests pass. The six original lifecycle regressions fail before the fix. Coverage feedback is addressed with additional JPEG MIME normalization, empty response, malformed content length, and stream timeout cases that also assert response cleanup. Ruff lint and formatting pass.
